### PR TITLE
[chore] DB 관리용 프로그램 연결 중 보안 강화를 위한 포트 번호 변경

### DIFF
--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     active: local
 
   datasource:
-    url: jdbc:mysql://localhost:3306/reviewticket
+    url: jdbc:mysql://localhost:21096/reviewticket
     username: reviewticket
     # password 는 application-local.yml 에 있다
 


### PR DESCRIPTION
Closes #38

MySQL 포트를 3306 에서 21096 으로 변경했다. 3306 은 스캐너 봇이 기본으로 찍어보는 포트라 자동 스캔 노이즈를 줄이기 위함이다.

저장소에 반영되는 건 `application.yml` 의 datasource URL 한 줄이고, 나머지 두 곳(서버 PC 의 `my.ini`, Windows 방화벽 규칙)은 저장소 밖이라 이미 직접 적용해 뒀다.

팀원은 DBeaver 접속시 Port 를 `21096` 으로 입력하면 된다. 백엔드는 이 PC 에서 공용으로 띄우므로 로컬에서 백엔드를 돌릴 일은 없다.