### PR TITLE
[feat] 가게 목록과 주문 API 구현

### DIFF
--- a/backend/DB/08_store_menu.sql
+++ b/backend/DB/08_store_menu.sql
@@ -1,0 +1,48 @@
+-- ReviewTicket — 가게와 메뉴
+--
+-- 가게 이름은 stores.name 이 정답이다. 사장 회원가입이 확정되는 순간
+-- (이메일 인증을 마치고 users 행이 만들어질 때) stores 행도 함께 만들면서
+-- users.display_name 을 복사한다. 그래서 사장은 가입만 하면 가게가 생긴다.
+--
+-- users.display_name 을 그대로 쓰지 않는 이유 — 그 값은 '계정 표시명'이고,
+-- 가게 이름은 나중에 따로 바뀔 수 있어야 한다. 한 사장이 가게를 여러 개
+-- 가지게 되는 경우도 users 쪽에는 담을 자리가 없다.
+--
+-- 실행:
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\08_store_menu.sql" |
+--     & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -h 127.0.0.1 -P 21096 -u root -p
+
+USE reviewticket;
+
+CREATE TABLE IF NOT EXISTS stores (
+  id            BIGINT       NOT NULL AUTO_INCREMENT,
+  owner_user_id BIGINT       NOT NULL,
+  name          VARCHAR(32)  NOT NULL,
+  image_url     VARCHAR(500) NULL COMMENT '목록 썸네일. NULL 이면 프론트가 회색 박스로 대체한다',
+  created_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+                                 ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (id),
+  -- 이름 UNIQUE 는 users.display_name 이 이미 UNIQUE 라 사실상 보장되지만,
+  -- 가게 이름을 따로 바꿀 수 있게 되면 그때는 이 제약이 유일한 방어선이 된다.
+  UNIQUE KEY uk_stores_name (name),
+  KEY ix_stores_owner (owner_user_id),
+  CONSTRAINT fk_stores_owner FOREIGN KEY (owner_user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS menus (
+  id           BIGINT       NOT NULL AUTO_INCREMENT,
+  store_id     BIGINT       NOT NULL,
+  name         VARCHAR(50)  NOT NULL,
+  price        INT          NOT NULL COMMENT '원 단위 정수. 콤마와 "원" 없이 18000 처럼 담는다',
+  image_url    VARCHAR(500) NULL,
+  review_event BOOLEAN      NOT NULL DEFAULT FALSE COMMENT '주문하면 리뷰를 쓸 수 있는 메뉴인지',
+  created_at   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+                                ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (id),
+  KEY ix_menus_store (store_id),
+  CONSTRAINT fk_menus_store FOREIGN KEY (store_id) REFERENCES stores (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/DB/09_order.sql
+++ b/backend/DB/09_order.sql
@@ -1,0 +1,37 @@
+-- ReviewTicket — 주문
+--
+-- 주문 1건 = 메뉴 1개다. 장바구니와 수량 개념이 없고, 메뉴 하나를 고르면
+-- 바로 주문이 만들어진다.
+--
+-- menu_name, price, review_event 는 menus 를 가리키는 대신 주문 시점의 값을
+-- 복사해 둔다(스냅샷). menu_id 로 매번 조인하면 사장이 가격을 올리는 순간
+-- 이미 지나간 주문의 금액까지 따라 바뀌고, 메뉴가 지워지면 과거 주문의
+-- 이름이 사라진다. 영수증은 그때 그 값으로 남아야 한다.
+--
+-- 실행:
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\09_order.sql" |
+--     & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -h 127.0.0.1 -P 21096 -u root -p
+
+USE reviewticket;
+
+CREATE TABLE IF NOT EXISTS orders (
+  id              BIGINT      NOT NULL AUTO_INCREMENT,
+  user_id         BIGINT      NOT NULL COMMENT '주문한 고객',
+  store_id        BIGINT      NOT NULL,
+  menu_id         BIGINT      NOT NULL,
+  menu_name       VARCHAR(50) NOT NULL COMMENT '주문 시점 스냅샷',
+  price           INT         NOT NULL COMMENT '주문 시점 스냅샷. 원 단위 정수',
+  review_event    BOOLEAN     NOT NULL COMMENT '주문 시점 스냅샷. 리뷰 대상 주문인지',
+  review_deadline DATETIME(3) NOT NULL COMMENT '리뷰 작성 마감 시각',
+  created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '주문 시각',
+
+  PRIMARY KEY (id),
+  -- 내 주문 내역을 최신순으로 읽는 것이 유일한 조회 패턴이라 이 조합으로 묶는다.
+  KEY ix_orders_user_created (user_id, created_at DESC),
+  KEY ix_orders_store (store_id),
+  CONSTRAINT fk_orders_user  FOREIGN KEY (user_id)  REFERENCES users (id)  ON DELETE CASCADE,
+  CONSTRAINT fk_orders_store FOREIGN KEY (store_id) REFERENCES stores (id),
+  -- 메뉴는 지워질 수 있다. 지워져도 주문은 남아야 하므로 CASCADE 를 걸지 않는다
+  -- (이름과 가격은 위 스냅샷 컬럼에 이미 복사돼 있다).
+  CONSTRAINT fk_orders_menu  FOREIGN KEY (menu_id)  REFERENCES menus (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
@@ -24,6 +24,7 @@ import com.reviewticket.server.mail.VerificationMailRequested;
 import com.reviewticket.server.repository.PasswordResetTokenRepository;
 import com.reviewticket.server.repository.PendingSignupRepository;
 import com.reviewticket.server.repository.UserRepository;
+import com.reviewticket.server.store.StoreService;
 
 /**
  * 가입, 이메일 인증, 로그인.
@@ -63,12 +64,13 @@ public class AuthService {
     private final ApplicationEventPublisher events;
     private final ReviewTicketProperties properties;
     private final EmailDomainValidator domainValidator;
+    private final StoreService storeService;
 
     public AuthService(UserRepository users, PendingSignupRepository pendings,
             PasswordResetTokenRepository resetTokens,
             PasswordEncoder passwordEncoder, JwtProvider jwtProvider,
             ApplicationEventPublisher events, ReviewTicketProperties properties,
-            EmailDomainValidator domainValidator) {
+            EmailDomainValidator domainValidator, StoreService storeService) {
         this.users = users;
         this.pendings = pendings;
         this.resetTokens = resetTokens;
@@ -77,6 +79,7 @@ public class AuthService {
         this.events = events;
         this.properties = properties;
         this.domainValidator = domainValidator;
+        this.storeService = storeService;
     }
 
     // ---------- 중복 검사 ----------
@@ -219,6 +222,13 @@ public class AuthService {
 
         User created = users.save(pending.toUser());
         pendings.delete(pending);
+
+        // 사장은 가입만 하면 가게가 생긴다. 가입 화면에서 받은 이름이 곧
+        // 가게 이름이므로, 여기서 만들지 않으면 사장이 가게를 따로 등록하기
+        // 전까지 고객 홈 목록에 아무것도 뜨지 않는다.
+        if (created.getRole() == Role.OWNER) {
+            storeService.createForOwner(created);
+        }
 
         log.info("회원 생성: id={} email={} role={}", created.getId(), created.getEmail(), created.getRole());
         return created.getEmail();

--- a/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** application.yml 의 reviewticket.* 를 그대로 받는다. */
 @ConfigurationProperties(prefix = "reviewticket")
-public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors cors) {
+public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors cors, Order order) {
 
     /**
      * @param jwtSecret       서명 키. 32바이트 이상. application-local.yml 에 둔다
@@ -21,6 +21,14 @@ public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors 
 
     /** @param from 발신 주소. 비어 있으면 메일을 보내지 않고 링크를 로그에 남긴다 */
     public record Mail(String from) {
+    }
+
+    /**
+     * @param reviewTtl 주문 후 리뷰를 쓸 수 있는 기간. 주문 시각에 이 값을 더해
+     *                  review_deadline 을 정한다. 정책이 바뀌면 이 줄만 고치면 되고,
+     *                  프론트는 서버가 내려준 마감 시각을 그대로 표시한다
+     */
+    public record Order(Duration reviewTtl) {
     }
 
     /**

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Menu.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Menu.java
@@ -1,0 +1,93 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 가게의 메뉴 한 줄.
+ *
+ * 가격은 원 단위 정수다. "18,000원" 같은 문자열로 두면 계산에 쓸 수 없고,
+ * 표시 형식은 화면마다 다를 수 있으므로 포맷은 프론트가 맡는다.
+ */
+@Entity
+@Table(name = "menus")
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    /** 이 메뉴를 주문하면 리뷰를 쓸 수 있는지. */
+    @Column(name = "review_event", nullable = false)
+    private boolean reviewEvent;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    protected Menu() {
+    }
+
+    public Menu(Store store, String name, int price, boolean reviewEvent) {
+        this.store = store;
+        this.name = name;
+        this.price = price;
+        this.reviewEvent = reviewEvent;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Store getStore() {
+        return store;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public boolean isReviewEvent() {
+        return reviewEvent;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Order.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Order.java
@@ -1,0 +1,116 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 주문 한 건. 주문 1건 = 메뉴 1개다 (장바구니와 수량 개념이 없다).
+ *
+ * menuName, price, reviewEvent 는 menu 를 가리키는 대신 주문 시점의 값을
+ * 복사해 둔다. 매번 조인하면 사장이 가격을 올릴 때 과거 주문 금액까지 따라
+ * 바뀌고, 메뉴가 지워지면 이름이 사라진다.
+ */
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(name = "menu_name", nullable = false, length = 50)
+    private String menuName;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "review_event", nullable = false)
+    private boolean reviewEvent;
+
+    @Column(name = "review_deadline", nullable = false)
+    private LocalDateTime reviewDeadline;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected Order() {
+    }
+
+    /** 스냅샷 세 값은 넘겨받은 메뉴에서 그 자리에서 복사한다. */
+    public Order(User user, Menu menu, LocalDateTime reviewDeadline) {
+        this.user = user;
+        this.store = menu.getStore();
+        this.menu = menu;
+        this.menuName = menu.getName();
+        this.price = menu.getPrice();
+        this.reviewEvent = menu.isReviewEvent();
+        this.reviewDeadline = reviewDeadline;
+    }
+
+    /**
+     * 지금 리뷰를 쓸 수 있는 주문인지. 리뷰 대상이면서 마감 전이어야 한다.
+     *
+     * "이미 리뷰를 썼는지"는 보지 않는다 — 리뷰 표가 아직 없다. 그 판정은
+     * 리뷰 기능이 붙을 때 pending 상태와 함께 추가한다.
+     */
+    public boolean isReviewable(LocalDateTime now) {
+        return reviewEvent && reviewDeadline.isAfter(now);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Store getStore() {
+        return store;
+    }
+
+    public Menu getMenu() {
+        return menu;
+    }
+
+    public String getMenuName() {
+        return menuName;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public boolean isReviewEvent() {
+        return reviewEvent;
+    }
+
+    public LocalDateTime getReviewDeadline() {
+        return reviewDeadline;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Store.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Store.java
@@ -1,0 +1,86 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 가게 한 곳. 사장 회원가입이 확정될 때 함께 만들어진다.
+ *
+ * 이름의 정답은 여기다 — users.display_name 은 계정 표시명이고, 가게 이름은
+ * 나중에 따로 바뀔 수 있어야 한다.
+ */
+@Entity
+@Table(name = "stores")
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_user_id", nullable = false)
+    private User owner;
+
+    @Column(nullable = false, length = 32)
+    private String name;
+
+    /** 없으면 프론트가 회색 박스로 대체한다. */
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    /** DB 의 DEFAULT / ON UPDATE 가 채운다. */
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    protected Store() {
+    }
+
+    public Store(User owner, String name) {
+        this.owner = owner;
+        this.name = name;
+    }
+
+    public void changeName(String newName) {
+        this.name = newName;
+    }
+
+    public void changeImageUrl(String newImageUrl) {
+        this.imageUrl = newImageUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderController.java
@@ -1,0 +1,51 @@
+package com.reviewticket.server.order;
+
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reviewticket.server.domain.User;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 주문. 대상 회원을 요청에서 받지 않는다 — 토큰의 주체가 곧 주문자다.
+ */
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    /**
+     * 가격은 받지 않는다. 서버가 menuId 로 조회해 담는다 —
+     * 프론트가 보낸 금액을 그대로 믿으면 고쳐 보낼 수 있다.
+     */
+    public record CreateOrderRequest(
+            @NotNull(message = "가게를 선택해 주세요") Long storeId,
+            @NotNull(message = "메뉴를 선택해 주세요") Long menuId) {
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public OrderResponse create(@AuthenticationPrincipal User user,
+            @Valid @RequestBody CreateOrderRequest request) {
+        return orderService.create(user, request.storeId(), request.menuId());
+    }
+
+    /** 로그인한 본인 주문만, 최신순. */
+    @GetMapping
+    public List<OrderResponse> myOrders(@AuthenticationPrincipal User user) {
+        return orderService.findMine(user);
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderResponse.java
@@ -1,0 +1,26 @@
+package com.reviewticket.server.order;
+
+import java.time.Instant;
+
+/**
+ * 주문내역 카드 한 장.
+ *
+ * @param menuName       주문 시점 스냅샷. 메뉴 이름이 나중에 바뀌어도 그대로다
+ * @param price          주문 시점 스냅샷. 원 단위 정수
+ * @param hasReviewBadge 리뷰 버튼을 띄울지 (주문 시점의 review_event)
+ * @param reviewStatus   "available" 이면 지금 리뷰를 쓸 수 있다. 그 밖에는
+ *                       "not_available". 이미 리뷰를 썼는지 보는 "pending" 은
+ *                       리뷰 표가 생길 때 붙인다
+ * @param reviewDeadline 리뷰 마감 시각. 화면의 남은 시간 카운트다운에 쓴다
+ */
+public record OrderResponse(
+        Long id,
+        Long storeId,
+        String storeName,
+        String menuName,
+        int price,
+        boolean hasReviewBadge,
+        String reviewStatus,
+        Instant reviewDeadline,
+        Instant createdAt) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
@@ -1,0 +1,83 @@
+package com.reviewticket.server.order;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reviewticket.server.auth.ValidationException;
+import com.reviewticket.server.config.ReviewTicketProperties;
+import com.reviewticket.server.domain.Menu;
+import com.reviewticket.server.domain.Order;
+import com.reviewticket.server.domain.User;
+import com.reviewticket.server.repository.MenuRepository;
+import com.reviewticket.server.repository.OrderRepository;
+
+/**
+ * 주문 생성과 조회.
+ *
+ * 가격은 요청에서 받지 않는다 — 프론트가 보낸 값을 그대로 저장하면 개발자
+ * 도구로 금액을 고쳐 보낼 수 있다. menuId 로 서버가 직접 조회해 담는다.
+ */
+@Service
+public class OrderService {
+
+    private final OrderRepository orders;
+    private final MenuRepository menus;
+    private final ReviewTicketProperties properties;
+
+    public OrderService(OrderRepository orders, MenuRepository menus, ReviewTicketProperties properties) {
+        this.orders = orders;
+        this.menus = menus;
+        this.properties = properties;
+    }
+
+    @Transactional
+    public OrderResponse create(User user, Long storeId, Long menuId) {
+        Menu menu = menus.findById(menuId)
+                .orElseThrow(() -> new ValidationException("MENU_NOT_FOUND", "메뉴를 찾을 수 없습니다"));
+
+        // storeId 를 믿지 않고 메뉴가 실제로 그 가게 것인지 확인한다. 어긋난
+        // 조합이 그대로 저장되면 주문 내역의 가게 이름이 엉뚱해진다.
+        if (!menu.getStore().getId().equals(storeId)) {
+            throw new ValidationException("MENU_STORE_MISMATCH", "메뉴가 해당 가게의 것이 아닙니다");
+        }
+
+        LocalDateTime deadline = LocalDateTime.now().plus(properties.order().reviewTtl());
+        Order saved = orders.save(new Order(user, menu, deadline));
+        return toResponse(saved);
+    }
+
+    /** 로그인한 본인 주문만. 최신 주문이 먼저 온다. */
+    @Transactional(readOnly = true)
+    public List<OrderResponse> findMine(User user) {
+        return orders.findMyOrders(user).stream()
+                .map(OrderService::toResponse)
+                .toList();
+    }
+
+    private static OrderResponse toResponse(Order order) {
+        return new OrderResponse(
+                order.getId(),
+                order.getStore().getId(),
+                order.getStore().getName(),
+                order.getMenuName(),
+                order.getPrice(),
+                order.isReviewEvent(),
+                order.isReviewable(LocalDateTime.now()) ? "available" : "not_available",
+                toUtc(order.getReviewDeadline()),
+                toUtc(order.getCreatedAt()));
+    }
+
+    /**
+     * 저장된 값은 서버 시간대(LocalDateTime)라 그대로 내보내면 "2026-08-04T09:30:00"
+     * 처럼 기준이 빠진 문자열이 된다. 프론트가 한국 시간으로 바꿔 표시하므로
+     * 기준이 분명한 UTC(끝에 Z)로 바꿔서 보낸다.
+     */
+    private static Instant toUtc(LocalDateTime serverTime) {
+        return serverTime == null ? null : serverTime.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
@@ -1,0 +1,23 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.reviewticket.server.domain.Menu;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    List<Menu> findByStoreIdOrderByIdAsc(Long storeId);
+
+    /**
+     * 리뷰 배지를 띄울 가게들의 id.
+     *
+     * 가게마다 메뉴를 한 번씩 조회하면 목록 길이만큼 쿼리가 늘어나므로
+     * (N+1), 배지가 붙는 가게 id 만 한 번에 받아 와서 메모리에서 맞춘다.
+     */
+    @Query("select distinct m.store.id from Menu m where m.reviewEvent = true and m.store.id in :storeIds")
+    List<Long> findStoreIdsWithReviewEvent(@Param("storeIds") List<Long> storeIds);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/OrderRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/OrderRepository.java
@@ -1,0 +1,22 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.reviewticket.server.domain.Order;
+import com.reviewticket.server.domain.User;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    /**
+     * 내 주문 내역, 최신순.
+     *
+     * store 를 함께 읽는 이유 — 응답에 가게 이름이 들어가는데 지연 로딩으로
+     * 두면 주문 건수만큼 추가 쿼리가 나간다(N+1).
+     */
+    @Query("select o from Order o join fetch o.store where o.user = :user order by o.id desc")
+    List<Order> findMyOrders(@Param("user") User user);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
@@ -1,0 +1,18 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reviewticket.server.domain.Store;
+import com.reviewticket.server.domain.User;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    /** 홈 목록. 최신 가게가 먼저 온다. */
+    List<Store> findAllByOrderByIdDesc();
+
+    boolean existsByOwner(User owner);
+
+    boolean existsByName(String name);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/MenuResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/MenuResponse.java
@@ -1,0 +1,10 @@
+package com.reviewticket.server.store;
+
+/** @param price 원 단위 정수. 표시 형식(콤마, "원")은 화면이 맡는다 */
+public record MenuResponse(
+        Long id,
+        String name,
+        int price,
+        String imageUrl,
+        boolean reviewEvent) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -1,0 +1,37 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 가게 조회.
+ *
+ * 두 라우터 모두 로그인이 필요하다 — SecurityConfig 가 /api/auth/** 를 뺀
+ * 나머지를 인증 대상으로 두고 있고, 홈 화면 자체가 로그인 뒤에 있다.
+ */
+@RestController
+@RequestMapping("/api/stores")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    public StoreController(StoreService storeService) {
+        this.storeService = storeService;
+    }
+
+    /** 홈 목록. 최신 가게가 먼저 온다. 개수 제한과 페이지네이션은 두지 않았다. */
+    @GetMapping
+    public List<StoreSummaryResponse> stores() {
+        return storeService.findAll();
+    }
+
+    /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */
+    @GetMapping("/{storeId}")
+    public StoreDetailResponse store(@PathVariable Long storeId) {
+        return storeService.findById(storeId);
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreDetailResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreDetailResponse.java
@@ -1,0 +1,13 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+
+/** 주문 화면용 가게 상세. 목록과 같은 정보에 메뉴 배열이 붙는다. */
+public record StoreDetailResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        double rating,
+        int reviewCount,
+        List<MenuResponse> menus) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -1,0 +1,99 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reviewticket.server.auth.ValidationException;
+import com.reviewticket.server.domain.Menu;
+import com.reviewticket.server.domain.Store;
+import com.reviewticket.server.domain.User;
+import com.reviewticket.server.repository.MenuRepository;
+import com.reviewticket.server.repository.StoreRepository;
+
+/**
+ * 가게 조회와 생성.
+ *
+ * rating 과 reviewCount 는 리뷰 표가 아직 없어 0 으로 내려간다. 화면은 이
+ * 값으로도 정상 동작하고, 리뷰 기능이 붙으면 이 서비스에서 계산해 채운다.
+ */
+@Service
+public class StoreService {
+
+    private final StoreRepository stores;
+    private final MenuRepository menus;
+
+    public StoreService(StoreRepository stores, MenuRepository menus) {
+        this.stores = stores;
+        this.menus = menus;
+    }
+
+    /**
+     * 사장 회원가입이 확정될 때 가게를 함께 만든다.
+     *
+     * 이미 가게가 있으면 아무것도 하지 않는다 — 가입 확정은 한 번뿐이지만,
+     * 이 메서드가 다른 경로에서 다시 불려도 가게가 둘로 늘지 않아야 한다.
+     */
+    @Transactional
+    public void createForOwner(User owner) {
+        if (stores.existsByOwner(owner)) {
+            return;
+        }
+        stores.save(new Store(owner, owner.getDisplayName()));
+    }
+
+    /** 홈 목록. 최신 가게가 먼저 온다. */
+    @Transactional(readOnly = true)
+    public List<StoreSummaryResponse> findAll() {
+        List<Store> found = stores.findAllByOrderByIdDesc();
+        if (found.isEmpty()) {
+            return List.of();
+        }
+
+        // 가게마다 메뉴를 따로 조회하면 목록 길이만큼 쿼리가 늘어난다(N+1).
+        // 배지가 붙는 가게 id 만 한 번에 받아 두고 메모리에서 맞춘다.
+        List<Long> ids = found.stream().map(Store::getId).toList();
+        Set<Long> withEvent = new HashSet<>(menus.findStoreIdsWithReviewEvent(ids));
+
+        return found.stream()
+                .map(store -> new StoreSummaryResponse(
+                        store.getId(),
+                        store.getName(),
+                        store.getImageUrl(),
+                        0.0,
+                        0,
+                        withEvent.contains(store.getId())))
+                .toList();
+    }
+
+    /** 주문 화면용 상세. 가게 정보에 그 가게 메뉴를 붙여 돌려준다. */
+    @Transactional(readOnly = true)
+    public StoreDetailResponse findById(Long storeId) {
+        Store store = stores.findById(storeId)
+                .orElseThrow(() -> new ValidationException("STORE_NOT_FOUND", "가게를 찾을 수 없습니다"));
+
+        List<MenuResponse> menuList = menus.findByStoreIdOrderByIdAsc(storeId).stream()
+                .map(StoreService::toMenuResponse)
+                .toList();
+
+        return new StoreDetailResponse(
+                store.getId(),
+                store.getName(),
+                store.getImageUrl(),
+                0.0,
+                0,
+                menuList);
+    }
+
+    private static MenuResponse toMenuResponse(Menu menu) {
+        return new MenuResponse(
+                menu.getId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getImageUrl(),
+                menu.isReviewEvent());
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreSummaryResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.reviewticket.server.store;
+
+/**
+ * 홈 목록의 가게 한 줄.
+ *
+ * @param rating         리뷰 평균 별점. 리뷰 표가 아직 없어 0 으로 나간다
+ * @param reviewCount    리뷰 개수. 같은 이유로 0
+ * @param hasReviewEvent 리뷰 대상 메뉴가 하나라도 있으면 true (가게 이름 옆 배지)
+ */
+public record StoreSummaryResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        double rating,
+        int reviewCount,
+        boolean hasReviewEvent) {
+}

--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -28,6 +28,14 @@ spring:
     # dialect 는 일부러 적지 않는다 — Boot 4/Hibernate 7 에서 MySQL8Dialect 같은
     # 버전별 이름이 제거됐다. 안 적으면 드라이버가 알아서 감지한다.
 
+  jackson:
+    serialization:
+      # 시각을 "2026-08-04T09:30:00Z" 같은 ISO 8601 문자열로 내보낸다.
+      # 켜 두면 숫자(에포크 초)로 나가서 프론트가 그대로 쓸 수 없다.
+      # Spring Boot 기본값도 false 지만, 주문 API 응답 형식이 여기에 달려 있어
+      # 나중에 누가 바꾸지 않도록 명시해 둔다.
+      write-dates-as-timestamps: false
+
 server:
   port: 60921
   tomcat:
@@ -58,6 +66,11 @@ reviewticket:
     # 발신 주소. 비우면 메일을 보내지 않고 인증 링크를 로그에 남긴다.
     # 실제 발송하려면 여기와 application-local.yml 의 spring.mail 을 채운다.
     from: ""
+  order:
+    # 주문 후 리뷰를 쓸 수 있는 기간. 지금은 개발 중이라 짧게 잡아 두었고,
+    # 마감 동작을 바로 확인할 수 있다. 실제 정책이 정해지면 이 줄만 고친다
+    # (프론트는 서버가 계산해 내려준 마감 시각을 그대로 표시한다).
+    review-ttl: 1m
   cors:
     # 쿠키를 쓰지 않고 Authorization 헤더로만 인증하므로(allowCredentials 꺼짐)
     # 출처를 전부 열어도 쿠키 기반 CSRF 같은 위험이 생기지 않는다.


### PR DESCRIPTION
Closes #42

프론트엔드 요청서 2건(가게 목록, 주문)에 대한 구현이다.

## 만든 것

표 3개 — `stores`, `menus`, `orders` (`backend/DB/08_store_menu.sql`, `09_order.sql`)

| 메서드 | 경로 | 설명 |
|---|---|---|
| GET | `/api/stores` | 홈 목록. 최신순 |
| GET | `/api/stores/{storeId}` | 상세 + 메뉴 배열 |
| POST | `/api/orders` | `{ "storeId": 1, "menuId": 10 }` |
| GET | `/api/orders` | 본인 주문, 최신순 |

## 결정한 것

**가게 이름은 `stores.name` 이 정답**이다. 대신 사장이 가게를 따로 등록하지 않아도 되도록, 이메일 인증이 확정돼 `users` 행이 만들어지는 시점에 `stores` 행도 함께 만들면서 `display_name` 을 복사한다. 같은 트랜잭션이라 가게 생성이 실패하면 회원 생성도 취소된다.

**주문에 가격을 받지 않는다.** 프론트가 보낸 금액을 그대로 저장하면 개발자 도구로 고쳐 보낼 수 있어, 서버가 `menuId` 로 조회해 담는다. `storeId` 도 믿지 않고 메뉴가 그 가게 것인지 확인한다.

**주문에 이름·가격·리뷰대상 여부를 복사해 둔다.** 매번 조인하면 사장이 가격을 올릴 때 지나간 주문 금액까지 따라 바뀐다.

**리뷰 제한시간은 `reviewticket.order.review-ttl` 설정값**으로 뺐다. 개발 중이라 `1m` 이고, 정책이 정해지면 이 줄만 고치면 된다.

**시각은 ISO 8601 UTC** 로 내보낸다. 저장은 기존과 같은 `LocalDateTime` 이라 응답에서 `Instant` 로 바꿔 기준을 분명히 했다.

`rating`, `reviewCount` 는 리뷰 표가 없어 0 으로 나간다. 요청서대로 화면은 이 값으로도 정상 동작한다.

## 남은 것

메뉴 등록 API 는 요청서에 없어 만들지 않았다. 그래서 지금은 `menus` 가 항상 빈 배열이고 주문도 넣을 수 없다 — 프론트에서 사장님 메뉴관리 요청이 오면 붙인다.

## 적용

`ddl-auto: validate` 라 표가 없으면 서버가 뜨지 않는다. 머지 후 각자 스키마를 먼저 반영해야 한다.