### PR TITLE
[feat] 가게·주문 API 추가와 응답 규약 정리

### DIFF
--- a/backend/DB/01_secure_and_provision.sql.example
+++ b/backend/DB/01_secure_and_provision.sql.example
@@ -6,7 +6,7 @@
 --                 (application-local.yml 에도 같은 값을 넣는다)
 --
 -- 실행:
---   Get-Content "C:\dev\ReviewTicket\BackEnd\DB\01_secure_and_provision.sql" | & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -u root --default-character-set=utf8mb4
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\01_secure_and_provision.sql" | & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -u root --default-character-set=utf8mb4
 --   (최초 설치 직후 root 는 빈 비밀번호라 -p 없이 접속된다)
 
 -- 1) root 비밀번호 설정
@@ -21,26 +21,48 @@ CREATE DATABASE IF NOT EXISTS reviewticket
 --
 -- @'localhost' 인 이유 — MySQL 계정은 (아이디, 접속 출처) 쌍이다. 이 계정은
 -- DB 와 같은 PC 에서만 쓸 수 있고, 외부에서는 비밀번호가 맞아도 거부된다.
-CREATE USER IF NOT EXISTS 'reviewticket'@'localhost' IDENTIFIED BY '__APP_PW__';
+--
+-- REQUIRE SSL 과 FAILED_LOGIN_ATTEMPTS/PASSWORD_LOCK_TIME 은 DB 포트를 인터넷에
+-- 열어둔 구조에서의 보안 강화 설정이다 (2026-08-01 도입).
+CREATE USER IF NOT EXISTS 'reviewticket'@'localhost'
+  IDENTIFIED BY '__APP_PW__'
+  REQUIRE SSL
+  FAILED_LOGIN_ATTEMPTS 5 PASSWORD_LOCK_TIME 3650;
 GRANT ALL PRIVILEGES ON reviewticket.* TO 'reviewticket'@'localhost';
+
+-- 4) 팀원이 DBeaver 등으로 원격 접속할 때 쓰는 같은 계정 (비번 동일).
+--    포트를 인터넷에 열어두는 구조라, 필요 없어지면 이 계정은 지운다.
+CREATE USER IF NOT EXISTS 'reviewticket'@'%'
+  IDENTIFIED BY '__APP_PW__'
+  REQUIRE SSL
+  FAILED_LOGIN_ATTEMPTS 5 PASSWORD_LOCK_TIME 3650;
+GRANT ALL PRIVILEGES ON reviewticket.* TO 'reviewticket'@'%';
+
 FLUSH PRIVILEGES;
 
--- 4) MySQL 을 외부 네트워크에 노출하지 않는다.
+-- 5) 포트를 기본값(3306)에서 옮긴다.
 --
--- 기본 설치는 모든 인터페이스(0.0.0.0:3306)에서 접속을 기다린다. 백엔드는
--- 같은 PC 에서 localhost 로 붙으므로(application.yml 의 jdbc:mysql://localhost)
--- 외부 노출이 필요 없고, 열어두면 DB 전체가 그대로 공격 표면이 된다.
+-- 팀원이 DBeaver 로 붙어야 해서 MySQL 을 외부에 열어 두었다. 3306 은 스캐너
+-- 봇이 가장 먼저 찍어보는 포트라, 그대로 두면 무차별 대입 시도가 끊이지
+-- 않는다 (SSH 22 번을 열었을 때 14 분 만에 시도가 들어온 적이 있다).
+-- 포트를 옮기는 것만으로 뚫리지 않게 되는 것은 아니고, 자동 스캔 소음을
+-- 줄이는 조치다. 실제 방어는 위의 REQUIRE SSL 과 계정 잠금이 맡는다.
 --
--- my.ini 의 [mysqld] 에 아래 한 줄을 넣는다. 접속을 거부하는 것이 아니라
--- 외부 인터페이스에서 아예 대기하지 않게 되므로, 계정 인증 단계까지 오지 못한다.
--- (파일 인코딩 문제를 피하려고 주석 없이 값만 넣는다)
+-- my.ini 의 [mysqld] 에 아래를 넣는다.
 --
---   bind-address=127.0.0.1
+--   port=21096
+--
+-- bind-address 는 넣지 않는다. 넣으면 그 주소에서만 대기해 외부에서 닿지
+-- 못하고, 그러면 팀원이 DBeaver 로 접속할 수 없다.
 --
 -- Windows 기본 경로: C:\ProgramData\MySQL\MySQL Server 8.4\my.ini
 -- 적용하려면 서비스 재시작: Restart-Service MySQL84
+-- 방화벽도 함께 열어야 한다:
+--   New-NetFirewallRule -DisplayName "ReviewTicket MySQL" -Direction Inbound -Protocol TCP -LocalPort 21096 -Action Allow -Profile Any
 --
--- 확인 — host 가 전부 localhost 여야 한다. % 인 계정이 있으면 어디서든
--- 접속할 수 있으므로 함께 정리한다.
+-- application.yml 의 datasource URL 도 같은 포트를 가리켜야 한다
+-- (jdbc:mysql://localhost:21096/reviewticket).
 --
---   SELECT user, host FROM mysql.user;
+-- 확인 — 두 계정 모두 ssl_type 이 ANY 여야 한다.
+--
+--   SELECT user, host, ssl_type FROM mysql.user WHERE user = 'reviewticket';

--- a/backend/DB/08_store_menu.sql
+++ b/backend/DB/08_store_menu.sql
@@ -1,0 +1,48 @@
+-- ReviewTicket — 가게와 메뉴
+--
+-- 가게 이름은 stores.name 이 정답이다. 사장 회원가입이 확정되는 순간
+-- (이메일 인증을 마치고 users 행이 만들어질 때) stores 행도 함께 만들면서
+-- users.display_name 을 복사한다. 그래서 사장은 가입만 하면 가게가 생긴다.
+--
+-- users.display_name 을 그대로 쓰지 않는 이유 — 그 값은 '계정 표시명'이고,
+-- 가게 이름은 나중에 따로 바뀔 수 있어야 한다. 한 사장이 가게를 여러 개
+-- 가지게 되는 경우도 users 쪽에는 담을 자리가 없다.
+--
+-- 실행:
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\08_store_menu.sql" |
+--     & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -h 127.0.0.1 -P 21096 -u root -p
+
+USE reviewticket;
+
+CREATE TABLE IF NOT EXISTS stores (
+  id            BIGINT       NOT NULL AUTO_INCREMENT,
+  owner_user_id BIGINT       NOT NULL,
+  name          VARCHAR(32)  NOT NULL,
+  image_url     VARCHAR(500) NULL COMMENT '목록 썸네일. NULL 이면 프론트가 회색 박스로 대체한다',
+  created_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+                                 ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (id),
+  -- 이름 UNIQUE 는 users.display_name 이 이미 UNIQUE 라 사실상 보장되지만,
+  -- 가게 이름을 따로 바꿀 수 있게 되면 그때는 이 제약이 유일한 방어선이 된다.
+  UNIQUE KEY uk_stores_name (name),
+  KEY ix_stores_owner (owner_user_id),
+  CONSTRAINT fk_stores_owner FOREIGN KEY (owner_user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS menus (
+  id           BIGINT       NOT NULL AUTO_INCREMENT,
+  store_id     BIGINT       NOT NULL,
+  name         VARCHAR(50)  NOT NULL,
+  price        INT          NOT NULL COMMENT '원 단위 정수. 콤마와 "원" 없이 18000 처럼 담는다',
+  image_url    VARCHAR(500) NULL,
+  review_event BOOLEAN      NOT NULL DEFAULT FALSE COMMENT '주문하면 리뷰를 쓸 수 있는 메뉴인지',
+  created_at   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  updated_at   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+                                ON UPDATE CURRENT_TIMESTAMP(3),
+
+  PRIMARY KEY (id),
+  KEY ix_menus_store (store_id),
+  CONSTRAINT fk_menus_store FOREIGN KEY (store_id) REFERENCES stores (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/DB/09_order.sql
+++ b/backend/DB/09_order.sql
@@ -1,0 +1,37 @@
+-- ReviewTicket — 주문
+--
+-- 주문 1건 = 메뉴 1개다. 장바구니와 수량 개념이 없고, 메뉴 하나를 고르면
+-- 바로 주문이 만들어진다.
+--
+-- menu_name, price, review_event 는 menus 를 가리키는 대신 주문 시점의 값을
+-- 복사해 둔다(스냅샷). menu_id 로 매번 조인하면 사장이 가격을 올리는 순간
+-- 이미 지나간 주문의 금액까지 따라 바뀌고, 메뉴가 지워지면 과거 주문의
+-- 이름이 사라진다. 영수증은 그때 그 값으로 남아야 한다.
+--
+-- 실행:
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\09_order.sql" |
+--     & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -h 127.0.0.1 -P 21096 -u root -p
+
+USE reviewticket;
+
+CREATE TABLE IF NOT EXISTS orders (
+  id              BIGINT      NOT NULL AUTO_INCREMENT,
+  user_id         BIGINT      NOT NULL COMMENT '주문한 고객',
+  store_id        BIGINT      NOT NULL,
+  menu_id         BIGINT      NOT NULL,
+  menu_name       VARCHAR(50) NOT NULL COMMENT '주문 시점 스냅샷',
+  price           INT         NOT NULL COMMENT '주문 시점 스냅샷. 원 단위 정수',
+  review_event    BOOLEAN     NOT NULL COMMENT '주문 시점 스냅샷. 리뷰 대상 주문인지',
+  review_deadline DATETIME(3) NOT NULL COMMENT '리뷰 작성 마감 시각',
+  created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '주문 시각',
+
+  PRIMARY KEY (id),
+  -- 내 주문 내역을 최신순으로 읽는 것이 유일한 조회 패턴이라 이 조합으로 묶는다.
+  KEY ix_orders_user_created (user_id, created_at DESC),
+  KEY ix_orders_store (store_id),
+  CONSTRAINT fk_orders_user  FOREIGN KEY (user_id)  REFERENCES users (id)  ON DELETE CASCADE,
+  CONSTRAINT fk_orders_store FOREIGN KEY (store_id) REFERENCES stores (id),
+  -- 메뉴는 지워질 수 있다. 지워져도 주문은 남아야 하므로 CASCADE 를 걸지 않는다
+  -- (이름과 가격은 위 스냅샷 컬럼에 이미 복사돼 있다).
+  CONSTRAINT fk_orders_menu  FOREIGN KEY (menu_id)  REFERENCES menus (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/Server/src/main/java/com/reviewticket/server/account/AccountService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/account/AccountService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.reviewticket.server.auth.ConflictException;
 import com.reviewticket.server.auth.UnauthorizedException;
+import com.reviewticket.server.auth.ValidationException;
 import com.reviewticket.server.domain.Role;
 import com.reviewticket.server.domain.User;
 import com.reviewticket.server.repository.PendingSignupRepository;
@@ -33,11 +34,11 @@ public class AccountService {
         User user = load(userId);
 
         if (name.isEmpty()) {
-            throw new IllegalArgumentException(
+            throw new ValidationException("NAME_REQUIRED",
                     user.getRole() == Role.OWNER ? "가게 이름을 입력해 주세요" : "닉네임을 입력해 주세요");
         }
         if (name.length() > 32) {
-            throw new IllegalArgumentException("이름은 32자 이하여야 합니다");
+            throw new ValidationException("NAME_TOO_LONG", "이름은 32자 이하여야 합니다");
         }
         // 지금 쓰는 이름을 그대로 다시 넣은 경우. 중복이라고 막으면 이상하다.
         if (name.equals(user.getDisplayName())) {
@@ -48,7 +49,7 @@ public class AccountService {
         // 대기자의 이름을 가로챌 수 있고, 그러면 그 사람이 인증 링크를 눌렀을 때
         // verify() 에서 충돌이 나 가입 자체가 무산된다.
         if (users.existsByDisplayName(name) || pendings.existsByDisplayName(name)) {
-            throw new ConflictException(
+            throw new ConflictException("NAME_TAKEN",
                     user.getRole() == Role.OWNER ? "이미 쓰이고 있는 가게 이름입니다" : "이미 쓰이고 있는 닉네임입니다");
         }
 
@@ -58,6 +59,6 @@ public class AccountService {
 
     private User load(long userId) {
         return users.findById(userId)
-                .orElseThrow(() -> new UnauthorizedException("로그인이 필요합니다"));
+                .orElseThrow(() -> new UnauthorizedException("UNAUTHORIZED", "로그인이 필요합니다"));
     }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthController.java
@@ -51,8 +51,12 @@ public class AuthController {
     /**
      * 회원 번호를 돌려주지 않는다 — 이 시점에는 회원이 아직 만들어지지 않았다.
      * 인증 링크를 눌러야 생성된다.
+     *
+     * 안내 문구도 담지 않는다. 성공했다는 사실은 상태 코드 200 으로 충분하고,
+     * "인증 메일을 보냈습니다" 같은 문장은 화면이 채운다. email 만 돌려주는 것은
+     * 서버가 정규화한 값(소문자·공백 제거)을 프론트가 그대로 쓰기 위해서다.
      */
-    public record SignUpResponse(String email, String message) {
+    public record SignUpResponse(String email) {
     }
 
     public record LoginRequest(
@@ -86,9 +90,6 @@ public class AuthController {
             @NotBlank(message = "토큰이 없습니다") String token,
             @NotBlank(message = "새 비밀번호를 입력해 주세요") String newPassword,
             @NotBlank(message = "새 비밀번호 확인을 입력해 주세요") String newPasswordConfirm) {
-    }
-
-    public record MessageResponse(String message) {
     }
 
     /** password-reset/request 성공 응답. code 값은 항상 "YES_EXISTING_EMAIL". */
@@ -127,8 +128,7 @@ public class AuthController {
             authService.requestSignUp(request.email(), request.password(),
                     request.role(), request.displayName());
             attemptLogger.record(AuthAction.SIGNUP, request.email(), request.displayName(), ip, true);
-            return new SignUpResponse(request.email().trim().toLowerCase(),
-                    "인증 메일을 보냈습니다. 메일의 링크를 눌러야 회원가입이 완료됩니다.");
+            return new SignUpResponse(request.email().trim().toLowerCase());
         } catch (RuntimeException e) {
             attemptLogger.record(AuthAction.SIGNUP, request.email(), request.displayName(), ip, false);
             throw e;
@@ -192,15 +192,18 @@ public class AuthController {
         return new ResetTokenResponse(authService.isResetTokenUsable(token));
     }
 
-    /** 페이지의 변경 버튼이 부른다. 여기서 실제 비밀번호가 바뀐다. */
+    /**
+     * 페이지의 변경 버튼이 부른다. 여기서 실제 비밀번호가 바뀐다.
+     *
+     * 성공하면 200 만 돌려준다 — 안내 문구는 화면이 채운다.
+     */
     @PostMapping(value = "/password-reset", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public MessageResponse resetPassword(@Valid @RequestBody ResetConfirm request, HttpServletRequest httpRequest) {
+    public void resetPassword(@Valid @RequestBody ResetConfirm request, HttpServletRequest httpRequest) {
         String ip = httpRequest.getRemoteAddr();
         String email = authService.resolveResetTokenEmail(request.token()).orElse(null);
         try {
             authService.resetPassword(request.token(), request.newPassword(), request.newPasswordConfirm());
             attemptLogger.record(AuthAction.PASSWORD_CHANGE, email, null, ip, true);
-            return new MessageResponse("비밀번호가 변경되었습니다. 새 비밀번호로 로그인해 주세요.");
         } catch (RuntimeException e) {
             attemptLogger.record(AuthAction.PASSWORD_CHANGE, email, null, ip, false);
             throw e;

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
@@ -57,6 +57,14 @@ final class AuthPages {
                 <button id="btn" onclick="finish()">회원가입 완료하기</button>
                 <div id="msg"></div>
                 <script>
+                  // 서버는 errorCode 만 보낸다. 문구는 여기서 채운다.
+                  var ERROR_TEXT = {
+                    VERIFY_TOKEN_INVALID: '인증 링크가 만료되었거나 이미 처리되었습니다.',
+                    VERIFY_TOKEN_EXPIRED: '인증 링크가 만료되었습니다. 회원가입을 다시 진행해 주세요.',
+                    EMAIL_TAKEN: '이미 가입된 이메일입니다.',
+                    NAME_TAKEN: '이미 쓰이고 있는 이름입니다. 회원가입을 다시 진행해 주세요.',
+                    TOO_MANY_REQUESTS: '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.'
+                  };
                   async function finish() {
                     var btn = document.getElementById('btn');
                     var msg = document.getElementById('msg');
@@ -75,7 +83,7 @@ final class AuthPages {
                         msg.textContent = '회원가입이 완료되었습니다. 이 창을 닫고 로그인해 주세요.';
                       } else {
                         msg.className = 'msg bad';
-                        msg.textContent = data.message || '처리에 실패했습니다.';
+                        msg.textContent = ERROR_TEXT[data.errorCode] || '처리에 실패했습니다.';
                         btn.disabled = false;
                       }
                     } catch (e) {
@@ -145,7 +153,10 @@ final class AuthPages {
                     PASSWORD_MISSING_UPPER: '대문자를 포함해주세요.',
                     PASSWORD_MISSING_LOWER: '소문자를 포함해주세요.',
                     PASSWORD_MISSING_DIGIT: '숫자를 포함해주세요.',
-                    PASSWORD_MISSING_SPECIAL: '특수문자를 포함해주세요.'
+                    PASSWORD_MISSING_SPECIAL: '특수문자를 포함해주세요.',
+                    PASSWORD_MISMATCH: '새 비밀번호가 서로 다릅니다.',
+                    RESET_TOKEN_INVALID: '재설정 링크가 올바르지 않습니다. 다시 요청해 주세요.',
+                    RESET_TOKEN_EXPIRED: '재설정 링크가 만료되었거나 이미 사용되었습니다. 다시 요청해 주세요.'
                   };
 
                   // 요청량 제한(429)에 걸린 동안 두 버튼을 잠그고 남은 시간을 센다.
@@ -242,7 +253,7 @@ final class AuthPages {
                       } else if (res.status === 429) {
                         startBlock(data.retryAfterSeconds);
                       } else {
-                        show('bad', ERROR_TEXT[data.errorCode] || data.message || '변경에 실패했습니다.');
+                        show('bad', ERROR_TEXT[data.errorCode] || '변경에 실패했습니다.');
                         btn.disabled = false;
                       }
                     } catch (e) {

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
@@ -135,14 +135,17 @@ final class AuthPages {
                   }
 
                   // 서버가 errorCode 만 보내므로(message 는 빠진다) 문구는 여기서 채운다.
+                  // 문구는 아래 passwordError() 가 돌려주는 것과 같게 맞춘다 — 서버와
+                  // 판정 순서가 같아 같은 조건에서 두 문구가 함께 뜰 수 있는데,
+                  // 그때 표현까지 다르면 서로 다른 지적을 받은 것처럼 보인다.
                   var ERROR_TEXT = {
-                    PASSWORD_TOO_SHORT: '비밀번호는 6자 이상이어야 합니다.',
-                    PASSWORD_TOO_LONG: '비밀번호는 14자 이하여야 합니다.',
-                    PASSWORD_INVALID_CHAR: '비밀번호에 쓸 수 없는 문자가 있습니다.',
-                    PASSWORD_MISSING_UPPER: '비밀번호에 대문자가 필요합니다.',
-                    PASSWORD_MISSING_LOWER: '비밀번호에 소문자가 필요합니다.',
-                    PASSWORD_MISSING_DIGIT: '비밀번호에 숫자가 필요합니다.',
-                    PASSWORD_MISSING_SPECIAL: '비밀번호에 특수문자가 필요합니다.'
+                    PASSWORD_TOO_SHORT: '6~14자리로 입력해주세요.',
+                    PASSWORD_TOO_LONG: '6~14자리로 입력해주세요.',
+                    PASSWORD_INVALID_CHAR: '사용할 수 없는 문자가 있습니다.',
+                    PASSWORD_MISSING_UPPER: '대문자를 포함해주세요.',
+                    PASSWORD_MISSING_LOWER: '소문자를 포함해주세요.',
+                    PASSWORD_MISSING_DIGIT: '숫자를 포함해주세요.',
+                    PASSWORD_MISSING_SPECIAL: '특수문자를 포함해주세요.'
                   };
 
                   // 가입 화면(SignUpForm 의 getPasswordError)과 같은 순서·문구를 쓴다.

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
@@ -34,6 +34,7 @@ final class AuthPages {
               input { width: 100%; box-sizing: border-box; padding: 0.6rem; margin-top: 0.4rem; border: 1px solid #cbd5e1; border-radius: 0.5rem; font-size: 1rem; }
               label { display: block; margin-top: 1rem; font-size: 0.9rem; font-weight: 600; }
               .hint { font-size: 0.85rem; color: #64748b; }
+              .field-error { margin-top: 0.4rem; font-size: 0.8rem; color: #b91c1c; }
               .msg { margin-top: 1rem; padding: 0.8rem; border-radius: 0.5rem; }
               .ok { background: #dcfce7; color: #166534; }
               .bad { background: #fee2e2; color: #991b1b; }
@@ -107,13 +108,15 @@ final class AuthPages {
                 </div>
 
                 <form id="step2" class="hidden" onsubmit="submitReset(event)">
-                  <p class="hint">새 비밀번호를 입력해 주세요. 대문자, 소문자, 숫자, 특수문자를 모두 포함해 8자 이상.</p>
+                  <p class="hint">새 비밀번호를 입력해 주세요.<br>비밀번호는 대문자, 소문자, 숫자, 특수문자를 모두 포함해 6자~14자 사이로 만들어 주세요.</p>
                   <label>새 비밀번호
-                    <input type="password" id="pw" autocomplete="new-password" required>
+                    <input type="password" id="pw" autocomplete="new-password" oninput="onPasswordInput()" required>
                   </label>
+                  <div id="pwError" class="field-error"></div>
                   <label>새 비밀번호 확인
-                    <input type="password" id="pw2" autocomplete="new-password" required>
+                    <input type="password" id="pw2" autocomplete="new-password" oninput="onConfirmInput()" required>
                   </label>
+                  <div id="pw2Error" class="field-error"></div>
                   <button type="submit" id="changeBtn">비밀번호 변경</button>
                 </form>
 
@@ -124,6 +127,48 @@ final class AuthPages {
                     var m = document.getElementById('msg');
                     m.className = 'msg ' + cls; m.textContent = text;
                   }
+                  // 줄바꿈이 필요한 곳에만 쓴다. 코드에 직접 적은 문구만 넘길 것 —
+                  // 서버가 보낸 값은 show() 로 넣어야 한다(그쪽은 textContent 라 안전하다).
+                  function showHtml(cls, html) {
+                    var m = document.getElementById('msg');
+                    m.className = 'msg ' + cls; m.innerHTML = html;
+                  }
+
+                  // 서버가 errorCode 만 보내므로(message 는 빠진다) 문구는 여기서 채운다.
+                  var ERROR_TEXT = {
+                    PASSWORD_TOO_SHORT: '비밀번호는 6자 이상이어야 합니다.',
+                    PASSWORD_TOO_LONG: '비밀번호는 14자 이하여야 합니다.',
+                    PASSWORD_INVALID_CHAR: '비밀번호에 쓸 수 없는 문자가 있습니다.',
+                    PASSWORD_MISSING_UPPER: '비밀번호에 대문자가 필요합니다.',
+                    PASSWORD_MISSING_LOWER: '비밀번호에 소문자가 필요합니다.',
+                    PASSWORD_MISSING_DIGIT: '비밀번호에 숫자가 필요합니다.',
+                    PASSWORD_MISSING_SPECIAL: '비밀번호에 특수문자가 필요합니다.'
+                  };
+
+                  // 가입 화면(SignUpForm 의 getPasswordError)과 같은 순서·문구를 쓴다.
+                  // 이 페이지는 React 앱과 분리돼 있어 그 함수를 가져다 쓸 수 없다.
+                  function passwordError(pw) {
+                    if (!pw) return '';
+                    if (!/[A-Z]/.test(pw)) return '대문자를 포함해주세요.';
+                    if (!/[a-z]/.test(pw)) return '소문자를 포함해주세요.';
+                    if (!/[0-9]/.test(pw)) return '숫자를 포함해주세요.';
+                    if (!/[!@#$%%^&*]/.test(pw)) return '특수문자를 포함해주세요.';
+                    if (/[^A-Za-z0-9!@#$%%^&*]/.test(pw)) return '사용할 수 없는 문자가 있습니다.';
+                    if (pw.length < 6 || pw.length > 14) return '6~14자리로 입력해주세요.';
+                    return '';
+                  }
+                  function onPasswordInput() {
+                    document.getElementById('pwError').textContent =
+                      passwordError(document.getElementById('pw').value);
+                    onConfirmInput();
+                  }
+                  function onConfirmInput() {
+                    var pw = document.getElementById('pw').value;
+                    var pw2 = document.getElementById('pw2').value;
+                    document.getElementById('pw2Error').textContent =
+                      (pw2 && pw !== pw2) ? '비밀번호가 서로 다릅니다.' : '';
+                  }
+
                   async function verify() {
                     var btn = document.getElementById('verifyBtn');
                     btn.disabled = true; show('', '확인 중…');
@@ -158,9 +203,9 @@ final class AuthPages {
                       var data = await res.json().catch(function(){ return {}; });
                       if (res.ok) {
                         document.getElementById('step2').classList.add('hidden');
-                        show('ok', '비밀번호가 변경되었습니다. 이 창을 닫고 새 비밀번호로 로그인해 주세요.');
+                        showHtml('ok', '비밀번호가 변경되었습니다.<br>이 창을 닫고 새 비밀번호로 로그인해 주세요.');
                       } else {
-                        show('bad', data.message || '변경에 실패했습니다.');
+                        show('bad', ERROR_TEXT[data.errorCode] || data.message || '변경에 실패했습니다.');
                         btn.disabled = false;
                       }
                     } catch (e) {

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthPages.java
@@ -148,6 +148,36 @@ final class AuthPages {
                     PASSWORD_MISSING_SPECIAL: '특수문자를 포함해주세요.'
                   };
 
+                  // 요청량 제한(429)에 걸린 동안 두 버튼을 잠그고 남은 시간을 센다.
+                  // 이 페이지가 보내는 요청은 세 번뿐이라 스스로 걸릴 일은 거의 없지만,
+                  // 같은 IP 의 다른 요청이 물통을 비우면 여기도 함께 막힌다.
+                  var blockTimer = null;
+                  function startBlock(seconds) {
+                    var until = Date.now() + (seconds || 0) * 1000;
+                    var verifyBtn = document.getElementById('verifyBtn');
+                    var changeBtn = document.getElementById('changeBtn');
+                    if (blockTimer) { clearInterval(blockTimer); }
+
+                    function tick() {
+                      var left = Math.ceil((until - Date.now()) / 1000);
+                      if (left <= 0) {
+                        clearInterval(blockTimer); blockTimer = null;
+                        verifyBtn.disabled = false; changeBtn.disabled = false;
+                        show('', '');
+                        return;
+                      }
+                      var m = Math.floor(left / 60);
+                      var s = left %% 60;
+                      show('bad', '요청이 너무 많습니다. ' + m + ':' + (s < 10 ? '0' + s : s)
+                        + ' 후 다시 시도해주세요.');
+                    }
+
+                    verifyBtn.disabled = true;
+                    changeBtn.disabled = true;
+                    tick();
+                    blockTimer = setInterval(tick, 1000);
+                  }
+
                   // 가입 화면(SignUpForm 의 getPasswordError)과 같은 순서·문구를 쓴다.
                   // 이 페이지는 React 앱과 분리돼 있어 그 함수를 가져다 쓸 수 없다.
                   function passwordError(pw) {
@@ -178,7 +208,9 @@ final class AuthPages {
                     try {
                       var res = await fetch('/api/auth/password-reset/check?token=' + encodeURIComponent(token));
                       var data = await res.json().catch(function(){ return {}; });
-                      if (res.ok && data.valid) {
+                      if (res.status === 429) {
+                        startBlock(data.retryAfterSeconds);
+                      } else if (res.ok && data.valid) {
                         document.getElementById('step1').classList.add('hidden');
                         document.getElementById('step2').classList.remove('hidden');
                         document.getElementById('msg').textContent = '';
@@ -207,6 +239,8 @@ final class AuthPages {
                       if (res.ok) {
                         document.getElementById('step2').classList.add('hidden');
                         showHtml('ok', '비밀번호가 변경되었습니다.<br>이 창을 닫고 새 비밀번호로 로그인해 주세요.');
+                      } else if (res.status === 429) {
+                        startBlock(data.retryAfterSeconds);
                       } else {
                         show('bad', ERROR_TEXT[data.errorCode] || data.message || '변경에 실패했습니다.');
                         btn.disabled = false;

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
@@ -160,7 +160,7 @@ public class AuthService {
         // 도메인의 MX 가 사라질 수 있고, 가입 당시 DNS 조회가 실패해
         // "판단 보류"로 통과한 건이 이 버튼으로 반복 발송될 수 있다.
         if (!domainValidator.hasMailServer(email)) {
-            throw new IllegalArgumentException("메일을 받을 수 없는 이메일 주소입니다");
+            throw new ValidationException("EMAIL_DOMAIN_INVALID", "메일을 받을 수 없는 이메일 주소입니다");
         }
 
         Optional<PendingSignup> found = pendings.findByEmail(email);
@@ -179,7 +179,7 @@ public class AuthService {
         // 그래서 최초 가입 직후 한 번만 막히고 그 뒤로는 무제한이었다.
         LocalDateTime lastSentAt = pending.getExpiresAt().minus(properties.auth().verificationTtl());
         if (lastSentAt.isAfter(LocalDateTime.now().minus(RESEND_COOLDOWN))) {
-            throw new IllegalArgumentException(
+            throw new ValidationException("RESEND_COOLDOWN",
                     "인증 메일을 방금 보냈습니다. " + RESEND_COOLDOWN.toSeconds() + "초 뒤에 다시 시도해 주세요");
         }
 
@@ -202,19 +202,19 @@ public class AuthService {
         PendingSignup pending = pendings.findByToken(token)
                 // 이미 인증을 마쳤거나(대기 건 삭제됨) 만료돼 정리된 경우도 여기로 온다.
                 // 어느 쪽인지 구분할 근거가 남아 있지 않으므로 한 문장으로 안내한다.
-                .orElseThrow(() -> new IllegalArgumentException(
+                .orElseThrow(() -> new ValidationException("VERIFY_TOKEN_INVALID",
                         "인증 링크가 만료되었거나 이미 처리되었습니다"));
 
         if (pending.isExpired(LocalDateTime.now())) {
-            throw new IllegalArgumentException("인증 링크가 만료되었습니다. 회원가입을 다시 진행해 주세요");
+            throw new ValidationException("VERIFY_TOKEN_EXPIRED", "인증 링크가 만료되었습니다");
         }
 
         // 대기하는 동안 다른 사람이 같은 이메일·이름으로 먼저 가입을 마쳤을 수 있다.
         if (users.existsByEmail(pending.getEmail())) {
-            throw new ConflictException("이미 가입된 이메일입니다");
+            throw new ConflictException("EMAIL_TAKEN", "이미 가입된 이메일입니다");
         }
         if (users.existsByDisplayName(pending.getDisplayName())) {
-            throw new ConflictException("이미 쓰이고 있는 이름입니다. 회원가입을 다시 진행해 주세요");
+            throw new ConflictException("NAME_TAKEN", "이미 쓰이고 있는 이름입니다");
         }
 
         User created = users.save(pending.toUser());
@@ -248,12 +248,12 @@ public class AuthService {
 
         if (found.isEmpty()) {
             passwordEncoder.matches(rawPassword, DUMMY_HASH);
-            throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다");
+            throw new UnauthorizedException("LOGIN_FAILED", "이메일 또는 비밀번호가 올바르지 않습니다");
         }
 
         User user = found.get();
         if (!passwordEncoder.matches(rawPassword, user.getPasswordHash())) {
-            throw new UnauthorizedException("이메일 또는 비밀번호가 올바르지 않습니다");
+            throw new UnauthorizedException("LOGIN_FAILED", "이메일 또는 비밀번호가 올바르지 않습니다");
         }
 
         return new LoginResult(jwtProvider.issue(user), jwtProvider.ttlSeconds(), user);
@@ -315,13 +315,13 @@ public class AuthService {
     @Transactional
     public void resetPassword(String token, String newPassword, String newPasswordConfirm) {
         PasswordResetToken reset = resetTokens.findByToken(token)
-                .orElseThrow(() -> new IllegalArgumentException("재설정 링크가 올바르지 않습니다"));
+                .orElseThrow(() -> new ValidationException("RESET_TOKEN_INVALID", "재설정 링크가 올바르지 않습니다"));
 
         if (!reset.isUsable(LocalDateTime.now())) {
-            throw new IllegalArgumentException("재설정 링크가 만료되었거나 이미 사용되었습니다. 다시 요청해 주세요");
+            throw new ValidationException("RESET_TOKEN_EXPIRED", "재설정 링크가 만료되었거나 이미 사용되었습니다");
         }
         if (!newPassword.equals(newPasswordConfirm)) {
-            throw new IllegalArgumentException("새 비밀번호가 서로 다릅니다");
+            throw new ValidationException("PASSWORD_MISMATCH", "새 비밀번호가 서로 다릅니다");
         }
         PasswordPolicy.require(newPassword);
 

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
@@ -24,6 +24,7 @@ import com.reviewticket.server.mail.VerificationMailRequested;
 import com.reviewticket.server.repository.PasswordResetTokenRepository;
 import com.reviewticket.server.repository.PendingSignupRepository;
 import com.reviewticket.server.repository.UserRepository;
+import com.reviewticket.server.store.StoreService;
 
 /**
  * 가입, 이메일 인증, 로그인.
@@ -63,12 +64,13 @@ public class AuthService {
     private final ApplicationEventPublisher events;
     private final ReviewTicketProperties properties;
     private final EmailDomainValidator domainValidator;
+    private final StoreService storeService;
 
     public AuthService(UserRepository users, PendingSignupRepository pendings,
             PasswordResetTokenRepository resetTokens,
             PasswordEncoder passwordEncoder, JwtProvider jwtProvider,
             ApplicationEventPublisher events, ReviewTicketProperties properties,
-            EmailDomainValidator domainValidator) {
+            EmailDomainValidator domainValidator, StoreService storeService) {
         this.users = users;
         this.pendings = pendings;
         this.resetTokens = resetTokens;
@@ -77,6 +79,7 @@ public class AuthService {
         this.events = events;
         this.properties = properties;
         this.domainValidator = domainValidator;
+        this.storeService = storeService;
     }
 
     // ---------- 중복 검사 ----------
@@ -219,6 +222,13 @@ public class AuthService {
 
         User created = users.save(pending.toUser());
         pendings.delete(pending);
+
+        // 사장은 가입만 하면 가게가 생긴다. 가입 화면에서 받은 이름이 곧
+        // 가게 이름이므로, 여기서 만들지 않으면 사장이 가게를 따로 등록하기
+        // 전까지 고객 홈 목록에 아무것도 뜨지 않는다.
+        if (created.getRole() == Role.OWNER) {
+            storeService.createForOwner(created);
+        }
 
         log.info("회원 생성: id={} email={} role={}", created.getId(), created.getEmail(), created.getRole());
         return created.getEmail();

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/ConflictException.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/ConflictException.java
@@ -11,11 +11,10 @@ public class ConflictException extends RuntimeException {
 
     private final String errorCode;
 
-    public ConflictException(String message) {
-        this(null, message);
-    }
-
-    /** errorCode 는 프론트가 문자열 비교 없이 분기할 수 있는 고정값. 없으면 null. */
+    /**
+     * errorCode 는 필수다 — 응답에 나가는 것은 이 코드뿐이고, 문구는 화면이
+     * 채운다. message 는 서버 로그와 스택트레이스에서 읽으려고 남긴다.
+     */
     public ConflictException(String errorCode, String message) {
         super(message);
         this.errorCode = errorCode;

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/LoginRateLimiter.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/LoginRateLimiter.java
@@ -35,15 +35,18 @@ public class LoginRateLimiter {
 
     private final ConcurrentHashMap<String, Attempt> attempts = new ConcurrentHashMap<>();
 
-    /** 로그인 시도 전에 부른다. 차단 중이면 예외를 던진다. */
+    /** 로그인 시도 전에 부른다. 차단 중이면 남은 시간과 함께 예외를 던진다. */
     public void checkAllowed(String ip) {
         Attempt a = attempts.get(ip);
         if (a == null) {
             return;
         }
         synchronized (a) {
-            if (a.blockedUntil != null && Instant.now().isBefore(a.blockedUntil)) {
-                throw new TooManyRequestsException("로그인 시도가 너무 많습니다. 잠시 후 다시 시도해 주세요.");
+            Instant now = Instant.now();
+            if (a.blockedUntil != null && now.isBefore(a.blockedUntil)) {
+                long remaining = Duration.between(now, a.blockedUntil).toSeconds();
+                throw new TooManyRequestsException(
+                        "로그인 시도가 너무 많습니다. 잠시 후 다시 시도해 주세요.", remaining);
             }
         }
     }

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/PasswordPolicy.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/PasswordPolicy.java
@@ -34,23 +34,28 @@ public final class PasswordPolicy {
     }
 
     /**
+     * 판정 순서는 가입 화면(SignUpForm 의 getPasswordError)과 같다 —
+     * 대문자, 소문자, 숫자, 특수문자, 사용 불가 문자, 길이.
+     *
+     * 순서를 맞춰야 하는 이유: 어긋난 조건이 여럿이어도 문구는 맨 앞에서 걸린
+     * 하나만 나간다. 서버가 길이를 먼저 보면, 같은 비밀번호를 두고 화면은
+     * "대문자를 포함해주세요"라고 하는데 서버는 "6자 이상이어야 합니다"라고
+     * 답하는 일이 생긴다. 판정 결과는 같아도 사용자는 서로 다른 지적을 받는다.
+     *
      * @return 어긋난 조건, 규칙을 지켰으면 null
      */
     public static Violation validate(String password) {
         if (password == null || password.isEmpty()) {
             return new Violation("PASSWORD_TOO_SHORT", "비밀번호를 입력해 주세요");
         }
-        if (password.length() < MIN_LENGTH) {
-            return new Violation("PASSWORD_TOO_SHORT", "비밀번호는 " + MIN_LENGTH + "자 이상이어야 합니다");
-        }
-        if (password.length() > MAX_LENGTH) {
-            return new Violation("PASSWORD_TOO_LONG", "비밀번호는 " + MAX_LENGTH + "자 이하여야 합니다");
-        }
 
+        // 문자 종류를 먼저 훑어 두고, 판정은 아래에서 순서대로 한다.
+        // 훑는 도중에 바로 돌려주면 "사용 불가 문자"가 대문자 검사보다 앞서게 된다.
         boolean upper = false;
         boolean lower = false;
         boolean digit = false;
         boolean special = false;
+        Character invalidChar = null;
         for (int i = 0; i < password.length(); i++) {
             char c = password.charAt(i);
             if (c >= 'A' && c <= 'Z') {
@@ -61,9 +66,10 @@ public final class PasswordPolicy {
                 digit = true;
             } else if (SPECIALS.indexOf(c) >= 0) {
                 special = true;
-            } else {
+            } else if (invalidChar == null) {
                 // 공백과 한글 등. 허용하면 나중에 본인도 못 치는 비밀번호가 생긴다.
-                return new Violation("PASSWORD_INVALID_CHAR", "비밀번호에 쓸 수 없는 문자가 있습니다: '" + c + "'");
+                // 첫 글자만 기억한다 — 어차피 한 번에 하나만 알려준다.
+                invalidChar = c;
             }
         }
 
@@ -78,6 +84,15 @@ public final class PasswordPolicy {
         }
         if (!special) {
             return new Violation("PASSWORD_MISSING_SPECIAL", "비밀번호에 특수문자가 필요합니다");
+        }
+        if (invalidChar != null) {
+            return new Violation("PASSWORD_INVALID_CHAR", "비밀번호에 쓸 수 없는 문자가 있습니다: '" + invalidChar + "'");
+        }
+        if (password.length() < MIN_LENGTH) {
+            return new Violation("PASSWORD_TOO_SHORT", "비밀번호는 " + MIN_LENGTH + "자 이상이어야 합니다");
+        }
+        if (password.length() > MAX_LENGTH) {
+            return new Violation("PASSWORD_TOO_LONG", "비밀번호는 " + MAX_LENGTH + "자 이하여야 합니다");
         }
         return null;
     }

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/TooManyRequestsException.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/TooManyRequestsException.java
@@ -1,9 +1,22 @@
 package com.reviewticket.server.auth;
 
-/** 요청 빈도 제한(rate limit)에 걸림. 429 로 나간다. */
+/**
+ * 요청 빈도 제한(rate limit)에 걸림. 429 로 나간다.
+ *
+ * 남은 차단 시간을 함께 담는다 — 화면이 "3:20 후 다시 시도해 주세요"처럼
+ * 남은 시간을 세어 보여주고 그동안 로그인·가입 버튼을 막는 데 쓴다.
+ * 이 값이 없으면 "잠시 후"라는 막연한 안내밖에 할 수 없다.
+ */
 public class TooManyRequestsException extends RuntimeException {
 
-    public TooManyRequestsException(String message) {
+    private final long retryAfterSeconds;
+
+    public TooManyRequestsException(String message, long retryAfterSeconds) {
         super(message);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long getRetryAfterSeconds() {
+        return retryAfterSeconds;
     }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/UnauthorizedException.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/UnauthorizedException.java
@@ -3,12 +3,20 @@ package com.reviewticket.server.auth;
 /**
  * 로그인 실패, 기존 비밀번호 불일치 등. 401 로 나간다.
  *
- * 메시지는 항상 뭉뚱그린다 — "이메일이 없습니다" 와 "비밀번호가 틀렸습니다"
- * 를 구분해 알려주면 어떤 이메일이 가입돼 있는지 알아낼 수 있다.
+ * 사유를 뭉뚱그린다 — "이메일이 없습니다" 와 "비밀번호가 틀렸습니다" 를
+ * 구분해 알려주면 어떤 이메일이 가입돼 있는지 알아낼 수 있다. 그래서
+ * 로그인 실패는 원인이 무엇이든 같은 코드로 나간다.
  */
 public class UnauthorizedException extends RuntimeException {
 
-    public UnauthorizedException(String message) {
+    private final String errorCode;
+
+    public UnauthorizedException(String errorCode, String message) {
         super(message);
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
     }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /** application.yml 의 reviewticket.* 를 그대로 받는다. */
 @ConfigurationProperties(prefix = "reviewticket")
-public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors cors) {
+public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors cors, Order order) {
 
     /**
      * @param jwtSecret       서명 키. 32바이트 이상. application-local.yml 에 둔다
@@ -21,6 +21,14 @@ public record ReviewTicketProperties(String demoDir, Auth auth, Mail mail, Cors 
 
     /** @param from 발신 주소. 비어 있으면 메일을 보내지 않고 링크를 로그에 남긴다 */
     public record Mail(String from) {
+    }
+
+    /**
+     * @param reviewTtl 주문 후 리뷰를 쓸 수 있는 기간. 주문 시각에 이 값을 더해
+     *                  review_deadline 을 정한다. 정책이 바뀌면 이 줄만 고치면 되고,
+     *                  프론트는 서버가 내려준 마감 시각을 그대로 표시한다
+     */
+    public record Order(Duration reviewTtl) {
     }
 
     /**

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Menu.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Menu.java
@@ -1,0 +1,93 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 가게의 메뉴 한 줄.
+ *
+ * 가격은 원 단위 정수다. "18,000원" 같은 문자열로 두면 계산에 쓸 수 없고,
+ * 표시 형식은 화면마다 다를 수 있으므로 포맷은 프론트가 맡는다.
+ */
+@Entity
+@Table(name = "menus")
+public class Menu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    /** 이 메뉴를 주문하면 리뷰를 쓸 수 있는지. */
+    @Column(name = "review_event", nullable = false)
+    private boolean reviewEvent;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    protected Menu() {
+    }
+
+    public Menu(Store store, String name, int price, boolean reviewEvent) {
+        this.store = store;
+        this.name = name;
+        this.price = price;
+        this.reviewEvent = reviewEvent;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Store getStore() {
+        return store;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public boolean isReviewEvent() {
+        return reviewEvent;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Order.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Order.java
@@ -1,0 +1,116 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 주문 한 건. 주문 1건 = 메뉴 1개다 (장바구니와 수량 개념이 없다).
+ *
+ * menuName, price, reviewEvent 는 menu 를 가리키는 대신 주문 시점의 값을
+ * 복사해 둔다. 매번 조인하면 사장이 가격을 올릴 때 과거 주문 금액까지 따라
+ * 바뀌고, 메뉴가 지워지면 이름이 사라진다.
+ */
+@Entity
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(name = "menu_name", nullable = false, length = 50)
+    private String menuName;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(name = "review_event", nullable = false)
+    private boolean reviewEvent;
+
+    @Column(name = "review_deadline", nullable = false)
+    private LocalDateTime reviewDeadline;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected Order() {
+    }
+
+    /** 스냅샷 세 값은 넘겨받은 메뉴에서 그 자리에서 복사한다. */
+    public Order(User user, Menu menu, LocalDateTime reviewDeadline) {
+        this.user = user;
+        this.store = menu.getStore();
+        this.menu = menu;
+        this.menuName = menu.getName();
+        this.price = menu.getPrice();
+        this.reviewEvent = menu.isReviewEvent();
+        this.reviewDeadline = reviewDeadline;
+    }
+
+    /**
+     * 지금 리뷰를 쓸 수 있는 주문인지. 리뷰 대상이면서 마감 전이어야 한다.
+     *
+     * "이미 리뷰를 썼는지"는 보지 않는다 — 리뷰 표가 아직 없다. 그 판정은
+     * 리뷰 기능이 붙을 때 pending 상태와 함께 추가한다.
+     */
+    public boolean isReviewable(LocalDateTime now) {
+        return reviewEvent && reviewDeadline.isAfter(now);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Store getStore() {
+        return store;
+    }
+
+    public Menu getMenu() {
+        return menu;
+    }
+
+    public String getMenuName() {
+        return menuName;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public boolean isReviewEvent() {
+        return reviewEvent;
+    }
+
+    public LocalDateTime getReviewDeadline() {
+        return reviewDeadline;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Store.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Store.java
@@ -1,0 +1,86 @@
+package com.reviewticket.server.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 가게 한 곳. 사장 회원가입이 확정될 때 함께 만들어진다.
+ *
+ * 이름의 정답은 여기다 — users.display_name 은 계정 표시명이고, 가게 이름은
+ * 나중에 따로 바뀔 수 있어야 한다.
+ */
+@Entity
+@Table(name = "stores")
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_user_id", nullable = false)
+    private User owner;
+
+    @Column(nullable = false, length = 32)
+    private String name;
+
+    /** 없으면 프론트가 회색 박스로 대체한다. */
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    /** DB 의 DEFAULT / ON UPDATE 가 채운다. */
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    protected Store() {
+    }
+
+    public Store(User owner, String name) {
+        this.owner = owner;
+        this.name = name;
+    }
+
+    public void changeName(String newName) {
+        this.name = newName;
+    }
+
+    public void changeImageUrl(String newImageUrl) {
+        this.imageUrl = newImageUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderController.java
@@ -1,0 +1,51 @@
+package com.reviewticket.server.order;
+
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.reviewticket.server.domain.User;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 주문. 대상 회원을 요청에서 받지 않는다 — 토큰의 주체가 곧 주문자다.
+ */
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    /**
+     * 가격은 받지 않는다. 서버가 menuId 로 조회해 담는다 —
+     * 프론트가 보낸 금액을 그대로 믿으면 고쳐 보낼 수 있다.
+     */
+    public record CreateOrderRequest(
+            @NotNull(message = "가게를 선택해 주세요") Long storeId,
+            @NotNull(message = "메뉴를 선택해 주세요") Long menuId) {
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public OrderResponse create(@AuthenticationPrincipal User user,
+            @Valid @RequestBody CreateOrderRequest request) {
+        return orderService.create(user, request.storeId(), request.menuId());
+    }
+
+    /** 로그인한 본인 주문만, 최신순. */
+    @GetMapping
+    public List<OrderResponse> myOrders(@AuthenticationPrincipal User user) {
+        return orderService.findMine(user);
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderResponse.java
@@ -1,0 +1,26 @@
+package com.reviewticket.server.order;
+
+import java.time.Instant;
+
+/**
+ * 주문내역 카드 한 장.
+ *
+ * @param menuName       주문 시점 스냅샷. 메뉴 이름이 나중에 바뀌어도 그대로다
+ * @param price          주문 시점 스냅샷. 원 단위 정수
+ * @param hasReviewBadge 리뷰 버튼을 띄울지 (주문 시점의 review_event)
+ * @param reviewStatus   "available" 이면 지금 리뷰를 쓸 수 있다. 그 밖에는
+ *                       "not_available". 이미 리뷰를 썼는지 보는 "pending" 은
+ *                       리뷰 표가 생길 때 붙인다
+ * @param reviewDeadline 리뷰 마감 시각. 화면의 남은 시간 카운트다운에 쓴다
+ */
+public record OrderResponse(
+        Long id,
+        Long storeId,
+        String storeName,
+        String menuName,
+        int price,
+        boolean hasReviewBadge,
+        String reviewStatus,
+        Instant reviewDeadline,
+        Instant createdAt) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
@@ -1,0 +1,83 @@
+package com.reviewticket.server.order;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reviewticket.server.auth.ValidationException;
+import com.reviewticket.server.config.ReviewTicketProperties;
+import com.reviewticket.server.domain.Menu;
+import com.reviewticket.server.domain.Order;
+import com.reviewticket.server.domain.User;
+import com.reviewticket.server.repository.MenuRepository;
+import com.reviewticket.server.repository.OrderRepository;
+
+/**
+ * 주문 생성과 조회.
+ *
+ * 가격은 요청에서 받지 않는다 — 프론트가 보낸 값을 그대로 저장하면 개발자
+ * 도구로 금액을 고쳐 보낼 수 있다. menuId 로 서버가 직접 조회해 담는다.
+ */
+@Service
+public class OrderService {
+
+    private final OrderRepository orders;
+    private final MenuRepository menus;
+    private final ReviewTicketProperties properties;
+
+    public OrderService(OrderRepository orders, MenuRepository menus, ReviewTicketProperties properties) {
+        this.orders = orders;
+        this.menus = menus;
+        this.properties = properties;
+    }
+
+    @Transactional
+    public OrderResponse create(User user, Long storeId, Long menuId) {
+        Menu menu = menus.findById(menuId)
+                .orElseThrow(() -> new ValidationException("MENU_NOT_FOUND", "메뉴를 찾을 수 없습니다"));
+
+        // storeId 를 믿지 않고 메뉴가 실제로 그 가게 것인지 확인한다. 어긋난
+        // 조합이 그대로 저장되면 주문 내역의 가게 이름이 엉뚱해진다.
+        if (!menu.getStore().getId().equals(storeId)) {
+            throw new ValidationException("MENU_STORE_MISMATCH", "메뉴가 해당 가게의 것이 아닙니다");
+        }
+
+        LocalDateTime deadline = LocalDateTime.now().plus(properties.order().reviewTtl());
+        Order saved = orders.save(new Order(user, menu, deadline));
+        return toResponse(saved);
+    }
+
+    /** 로그인한 본인 주문만. 최신 주문이 먼저 온다. */
+    @Transactional(readOnly = true)
+    public List<OrderResponse> findMine(User user) {
+        return orders.findMyOrders(user).stream()
+                .map(OrderService::toResponse)
+                .toList();
+    }
+
+    private static OrderResponse toResponse(Order order) {
+        return new OrderResponse(
+                order.getId(),
+                order.getStore().getId(),
+                order.getStore().getName(),
+                order.getMenuName(),
+                order.getPrice(),
+                order.isReviewEvent(),
+                order.isReviewable(LocalDateTime.now()) ? "available" : "not_available",
+                toUtc(order.getReviewDeadline()),
+                toUtc(order.getCreatedAt()));
+    }
+
+    /**
+     * 저장된 값은 서버 시간대(LocalDateTime)라 그대로 내보내면 "2026-08-04T09:30:00"
+     * 처럼 기준이 빠진 문자열이 된다. 프론트가 한국 시간으로 바꿔 표시하므로
+     * 기준이 분명한 UTC(끝에 Z)로 바꿔서 보낸다.
+     */
+    private static Instant toUtc(LocalDateTime serverTime) {
+        return serverTime == null ? null : serverTime.atZone(ZoneId.systemDefault()).toInstant();
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
@@ -1,0 +1,23 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.reviewticket.server.domain.Menu;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+
+    List<Menu> findByStoreIdOrderByIdAsc(Long storeId);
+
+    /**
+     * 리뷰 배지를 띄울 가게들의 id.
+     *
+     * 가게마다 메뉴를 한 번씩 조회하면 목록 길이만큼 쿼리가 늘어나므로
+     * (N+1), 배지가 붙는 가게 id 만 한 번에 받아 와서 메모리에서 맞춘다.
+     */
+    @Query("select distinct m.store.id from Menu m where m.reviewEvent = true and m.store.id in :storeIds")
+    List<Long> findStoreIdsWithReviewEvent(@Param("storeIds") List<Long> storeIds);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/OrderRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/OrderRepository.java
@@ -1,0 +1,22 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.reviewticket.server.domain.Order;
+import com.reviewticket.server.domain.User;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    /**
+     * 내 주문 내역, 최신순.
+     *
+     * store 를 함께 읽는 이유 — 응답에 가게 이름이 들어가는데 지연 로딩으로
+     * 두면 주문 건수만큼 추가 쿼리가 나간다(N+1).
+     */
+    @Query("select o from Order o join fetch o.store where o.user = :user order by o.id desc")
+    List<Order> findMyOrders(@Param("user") User user);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
@@ -1,0 +1,18 @@
+package com.reviewticket.server.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.reviewticket.server.domain.Store;
+import com.reviewticket.server.domain.User;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    /** 홈 목록. 최신 가게가 먼저 온다. */
+    List<Store> findAllByOrderByIdDesc();
+
+    boolean existsByOwner(User owner);
+
+    boolean existsByName(String name);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/MenuResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/MenuResponse.java
@@ -1,0 +1,10 @@
+package com.reviewticket.server.store;
+
+/** @param price 원 단위 정수. 표시 형식(콤마, "원")은 화면이 맡는다 */
+public record MenuResponse(
+        Long id,
+        String name,
+        int price,
+        String imageUrl,
+        boolean reviewEvent) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -1,0 +1,37 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 가게 조회.
+ *
+ * 두 라우터 모두 로그인이 필요하다 — SecurityConfig 가 /api/auth/** 를 뺀
+ * 나머지를 인증 대상으로 두고 있고, 홈 화면 자체가 로그인 뒤에 있다.
+ */
+@RestController
+@RequestMapping("/api/stores")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    public StoreController(StoreService storeService) {
+        this.storeService = storeService;
+    }
+
+    /** 홈 목록. 최신 가게가 먼저 온다. 개수 제한과 페이지네이션은 두지 않았다. */
+    @GetMapping
+    public List<StoreSummaryResponse> stores() {
+        return storeService.findAll();
+    }
+
+    /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */
+    @GetMapping("/{storeId}")
+    public StoreDetailResponse store(@PathVariable Long storeId) {
+        return storeService.findById(storeId);
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreDetailResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreDetailResponse.java
@@ -1,0 +1,13 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+
+/** 주문 화면용 가게 상세. 목록과 같은 정보에 메뉴 배열이 붙는다. */
+public record StoreDetailResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        double rating,
+        int reviewCount,
+        List<MenuResponse> menus) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -1,0 +1,99 @@
+package com.reviewticket.server.store;
+
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.reviewticket.server.auth.ValidationException;
+import com.reviewticket.server.domain.Menu;
+import com.reviewticket.server.domain.Store;
+import com.reviewticket.server.domain.User;
+import com.reviewticket.server.repository.MenuRepository;
+import com.reviewticket.server.repository.StoreRepository;
+
+/**
+ * 가게 조회와 생성.
+ *
+ * rating 과 reviewCount 는 리뷰 표가 아직 없어 0 으로 내려간다. 화면은 이
+ * 값으로도 정상 동작하고, 리뷰 기능이 붙으면 이 서비스에서 계산해 채운다.
+ */
+@Service
+public class StoreService {
+
+    private final StoreRepository stores;
+    private final MenuRepository menus;
+
+    public StoreService(StoreRepository stores, MenuRepository menus) {
+        this.stores = stores;
+        this.menus = menus;
+    }
+
+    /**
+     * 사장 회원가입이 확정될 때 가게를 함께 만든다.
+     *
+     * 이미 가게가 있으면 아무것도 하지 않는다 — 가입 확정은 한 번뿐이지만,
+     * 이 메서드가 다른 경로에서 다시 불려도 가게가 둘로 늘지 않아야 한다.
+     */
+    @Transactional
+    public void createForOwner(User owner) {
+        if (stores.existsByOwner(owner)) {
+            return;
+        }
+        stores.save(new Store(owner, owner.getDisplayName()));
+    }
+
+    /** 홈 목록. 최신 가게가 먼저 온다. */
+    @Transactional(readOnly = true)
+    public List<StoreSummaryResponse> findAll() {
+        List<Store> found = stores.findAllByOrderByIdDesc();
+        if (found.isEmpty()) {
+            return List.of();
+        }
+
+        // 가게마다 메뉴를 따로 조회하면 목록 길이만큼 쿼리가 늘어난다(N+1).
+        // 배지가 붙는 가게 id 만 한 번에 받아 두고 메모리에서 맞춘다.
+        List<Long> ids = found.stream().map(Store::getId).toList();
+        Set<Long> withEvent = new HashSet<>(menus.findStoreIdsWithReviewEvent(ids));
+
+        return found.stream()
+                .map(store -> new StoreSummaryResponse(
+                        store.getId(),
+                        store.getName(),
+                        store.getImageUrl(),
+                        0.0,
+                        0,
+                        withEvent.contains(store.getId())))
+                .toList();
+    }
+
+    /** 주문 화면용 상세. 가게 정보에 그 가게 메뉴를 붙여 돌려준다. */
+    @Transactional(readOnly = true)
+    public StoreDetailResponse findById(Long storeId) {
+        Store store = stores.findById(storeId)
+                .orElseThrow(() -> new ValidationException("STORE_NOT_FOUND", "가게를 찾을 수 없습니다"));
+
+        List<MenuResponse> menuList = menus.findByStoreIdOrderByIdAsc(storeId).stream()
+                .map(StoreService::toMenuResponse)
+                .toList();
+
+        return new StoreDetailResponse(
+                store.getId(),
+                store.getName(),
+                store.getImageUrl(),
+                0.0,
+                0,
+                menuList);
+    }
+
+    private static MenuResponse toMenuResponse(Menu menu) {
+        return new MenuResponse(
+                menu.getId(),
+                menu.getName(),
+                menu.getPrice(),
+                menu.getImageUrl(),
+                menu.isReviewEvent());
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -32,7 +32,26 @@ public class StoreService {
     }
 
     /**
-     * 사장 회원가입이 확정될 때 가게를 함께 만든다.
+     * 프로토타입용 기본 메뉴.
+     *
+     * 사장이 메뉴를 등록하는 API 가 아직 없어서, 가게를 만들 때 이 다섯 개를
+     * 함께 넣는다. 그러지 않으면 가게는 있는데 메뉴가 비어 있어 고객 화면의
+     * 주문 흐름을 확인할 수 없다.
+     *
+     * 메뉴관리 API 가 붙으면 이 상수와 아래 생성 코드를 지운다.
+     */
+    private record SeedMenu(String name, int price, boolean reviewEvent) {
+    }
+
+    private static final List<SeedMenu> SEED_MENUS = List.of(
+            new SeedMenu("피자", 18000, true),
+            new SeedMenu("햄버거", 9000, true),
+            new SeedMenu("치킨윙", 15000, false),
+            new SeedMenu("파스타", 13000, true),
+            new SeedMenu("샐러드", 8000, false));
+
+    /**
+     * 사장 회원가입이 확정될 때 가게와 기본 메뉴를 함께 만든다.
      *
      * 이미 가게가 있으면 아무것도 하지 않는다 — 가입 확정은 한 번뿐이지만,
      * 이 메서드가 다른 경로에서 다시 불려도 가게가 둘로 늘지 않아야 한다.
@@ -42,7 +61,10 @@ public class StoreService {
         if (stores.existsByOwner(owner)) {
             return;
         }
-        stores.save(new Store(owner, owner.getDisplayName()));
+        Store store = stores.save(new Store(owner, owner.getDisplayName()));
+        menus.saveAll(SEED_MENUS.stream()
+                .map(seed -> new Menu(store, seed.name(), seed.price(), seed.reviewEvent()))
+                .toList());
     }
 
     /** 홈 목록. 최신 가게가 먼저 온다. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreSummaryResponse.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.reviewticket.server.store;
+
+/**
+ * 홈 목록의 가게 한 줄.
+ *
+ * @param rating         리뷰 평균 별점. 리뷰 표가 아직 없어 0 으로 나간다
+ * @param reviewCount    리뷰 개수. 같은 이유로 0
+ * @param hasReviewEvent 리뷰 대상 메뉴가 하나라도 있으면 true (가게 이름 옆 배지)
+ */
+public record StoreSummaryResponse(
+        Long id,
+        String name,
+        String imageUrl,
+        double rating,
+        int reviewCount,
+        boolean hasReviewEvent) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/web/ApiExceptionHandler.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/web/ApiExceptionHandler.java
@@ -31,7 +31,7 @@ public class ApiExceptionHandler {
      * 안 붙인 곳)는 지금처럼 message 를 그대로 내려준다.
      */
     private static ResponseEntity<Map<String, Object>> body(
-            HttpStatus status, String errorCode, String message, boolean retryable) {
+            HttpStatus status, String errorCode, String message) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("error", status.getReasonPhrase());
         if (errorCode != null) {
@@ -39,14 +39,13 @@ public class ApiExceptionHandler {
         } else {
             payload.put("message", message);
         }
-        payload.put("retryable", retryable);
         return ResponseEntity.status(status).body(payload);
     }
 
     @ExceptionHandler({ IllegalArgumentException.class, ConstraintViolationException.class })
     public ResponseEntity<Map<String, Object>> badRequest(Exception e) {
         String errorCode = e instanceof ValidationException ve ? ve.getErrorCode() : null;
-        return body(HttpStatus.BAD_REQUEST, errorCode, e.getMessage(), false);
+        return body(HttpStatus.BAD_REQUEST, errorCode, e.getMessage());
     }
 
     /** @Valid 가 걸린 요청 본문의 첫 위반 사유를 그대로 보여준다. */
@@ -57,13 +56,13 @@ public class ApiExceptionHandler {
                 .filter(m -> m != null && !m.isBlank())
                 .findFirst()
                 .orElse("입력값이 올바르지 않습니다");
-        return body(HttpStatus.BAD_REQUEST, null, message, false);
+        return body(HttpStatus.BAD_REQUEST, null, message);
     }
 
     /** 이미 쓰이고 있는 이메일·닉네임. 형식 오류와 달리 다른 값을 쓰라고 안내해야 한다. */
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<Map<String, Object>> conflict(ConflictException e) {
-        return body(HttpStatus.CONFLICT, e.getErrorCode(), e.getMessage(), false);
+        return body(HttpStatus.CONFLICT, e.getErrorCode(), e.getMessage());
     }
 
     /**
@@ -80,18 +79,29 @@ public class ApiExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, Object>> constraintViolation(DataIntegrityViolationException e) {
         log.warn("DB 제약 위반 (동시 요청 경합으로 추정)", e);
-        return body(HttpStatus.CONFLICT, null,
-                "이미 사용 중인 정보입니다. 다시 시도해 주세요.", true);
+        return body(HttpStatus.CONFLICT, null, "이미 사용 중인 정보입니다. 다시 시도해 주세요.");
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<Map<String, Object>> unauthorized(UnauthorizedException e) {
-        return body(HttpStatus.UNAUTHORIZED, null, e.getMessage(), false);
+        return body(HttpStatus.UNAUTHORIZED, null, e.getMessage());
     }
 
+    /**
+     * 남은 차단 시간을 함께 보낸다. 화면이 그 시간을 세어 보여주고, 그동안
+     * 로그인·가입 버튼을 막는다. Retry-After 헤더로도 같은 값을 보내지만
+     * 본문에 넣는 이유는 — 프론트가 다른 출처에서 뜨는 경우 헤더를 읽으려면
+     * CORS 노출 설정이 따로 필요한데, 본문은 그런 제약이 없다.
+     */
     @ExceptionHandler(TooManyRequestsException.class)
     public ResponseEntity<Map<String, Object>> tooManyRequests(TooManyRequestsException e) {
-        return body(HttpStatus.TOO_MANY_REQUESTS, null, e.getMessage(), true);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("error", HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase());
+        payload.put("errorCode", "TOO_MANY_REQUESTS");
+        payload.put("retryAfterSeconds", e.getRetryAfterSeconds());
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", String.valueOf(e.getRetryAfterSeconds()))
+                .body(payload);
     }
 
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/web/ApiExceptionHandler.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/web/ApiExceptionHandler.java
@@ -26,43 +26,48 @@ public class ApiExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
     /**
-     * errorCode 가 있으면 message 는 응답에서 뺀다 — 문구는 프론트가 errorCode 로
-     * 직접 채운다. errorCode 가 없는 예외(로그인, 비밀번호 재설정 등 아직 코드를
-     * 안 붙인 곳)는 지금처럼 message 를 그대로 내려준다.
+     * 응답에는 errorCode 만 담는다. 사용자에게 보여줄 문구는 화면이 그 코드를
+     * 보고 채운다 — 문구를 서버가 정하면 어투 하나 고칠 때마다 화면의 분기가
+     * 조용히 깨진다.
+     *
+     * 예외의 message 는 응답에 싣지 않고 서버 로그와 스택트레이스에만 남긴다.
      */
-    private static ResponseEntity<Map<String, Object>> body(
-            HttpStatus status, String errorCode, String message) {
+    private static ResponseEntity<Map<String, Object>> body(HttpStatus status, String errorCode) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("error", status.getReasonPhrase());
-        if (errorCode != null) {
-            payload.put("errorCode", errorCode);
-        } else {
-            payload.put("message", message);
-        }
+        payload.put("errorCode", errorCode);
         return ResponseEntity.status(status).body(payload);
     }
 
     @ExceptionHandler({ IllegalArgumentException.class, ConstraintViolationException.class })
     public ResponseEntity<Map<String, Object>> badRequest(Exception e) {
-        String errorCode = e instanceof ValidationException ve ? ve.getErrorCode() : null;
-        return body(HttpStatus.BAD_REQUEST, errorCode, e.getMessage());
+        if (e instanceof ValidationException ve) {
+            return body(HttpStatus.BAD_REQUEST, ve.getErrorCode());
+        }
+        // 코드를 붙이지 않은 곳에서 올라온 경우. 화면은 일반 안내로 처리한다.
+        log.warn("errorCode 없는 400", e);
+        return body(HttpStatus.BAD_REQUEST, "INVALID_REQUEST");
     }
 
-    /** @Valid 가 걸린 요청 본문의 첫 위반 사유를 그대로 보여준다. */
+    /**
+     * @Valid 위반. 어느 필드가 왜 틀렸는지는 응답에 담지 않고 로그로만 남긴다 —
+     * 이 경로는 화면이 이미 같은 규칙으로 걸러 낸 뒤라 정상 사용자는 닿지 않는다.
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> invalidBody(MethodArgumentNotValidException e) {
-        String message = e.getFieldErrors().stream()
+        String reason = e.getFieldErrors().stream()
                 .map(FieldError::getDefaultMessage)
                 .filter(m -> m != null && !m.isBlank())
                 .findFirst()
                 .orElse("입력값이 올바르지 않습니다");
-        return body(HttpStatus.BAD_REQUEST, null, message);
+        log.warn("요청 본문 검증 실패: {}", reason);
+        return body(HttpStatus.BAD_REQUEST, "INVALID_REQUEST");
     }
 
     /** 이미 쓰이고 있는 이메일·닉네임. 형식 오류와 달리 다른 값을 쓰라고 안내해야 한다. */
     @ExceptionHandler(ConflictException.class)
     public ResponseEntity<Map<String, Object>> conflict(ConflictException e) {
-        return body(HttpStatus.CONFLICT, e.getErrorCode(), e.getMessage());
+        return body(HttpStatus.CONFLICT, e.getErrorCode());
     }
 
     /**
@@ -79,12 +84,12 @@ public class ApiExceptionHandler {
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, Object>> constraintViolation(DataIntegrityViolationException e) {
         log.warn("DB 제약 위반 (동시 요청 경합으로 추정)", e);
-        return body(HttpStatus.CONFLICT, null, "이미 사용 중인 정보입니다. 다시 시도해 주세요.");
+        return body(HttpStatus.CONFLICT, "ALREADY_IN_USE");
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<Map<String, Object>> unauthorized(UnauthorizedException e) {
-        return body(HttpStatus.UNAUTHORIZED, null, e.getMessage());
+        return body(HttpStatus.UNAUTHORIZED, e.getErrorCode());
     }
 
     /**

--- a/backend/Server/src/main/java/com/reviewticket/server/web/RateLimitFilter.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/web/RateLimitFilter.java
@@ -42,14 +42,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
         // 프록시를 두게 되면 그때 그 프록시가 붙인 값만 받도록 바꾼다.
         long retryAfter = ipLimiter.retryAfterSeconds(request.getRemoteAddr());
         if (retryAfter > 0) {
-            reject(response, HttpStatus.TOO_MANY_REQUESTS, retryAfter,
-                    "요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.");
+            reject(response, HttpStatus.TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", retryAfter);
             return;
         }
 
         if (!concurrentLimiter.tryAcquire()) {
-            reject(response, HttpStatus.SERVICE_UNAVAILABLE, 1,
-                    "서버가 혼잡합니다. 잠시 후 다시 시도해 주세요.");
+            reject(response, HttpStatus.SERVICE_UNAVAILABLE, "SERVER_BUSY", 1);
             return;
         }
 
@@ -61,9 +59,15 @@ public class RateLimitFilter extends OncePerRequestFilter {
         }
     }
 
-    /** 응답 형식을 ApiExceptionHandler 와 같게 맞춘다. 프론트가 message 만 보면 된다. */
-    private void reject(HttpServletResponse response, HttpStatus status, long retryAfterSeconds,
-            String message) throws IOException {
+    /**
+     * 응답 형식을 ApiExceptionHandler 와 같게 맞춘다. 문구는 담지 않는다 —
+     * errorCode 로 프론트가 채우고, retryAfterSeconds 로 남은 시간을 세어 보여준다.
+     *
+     * 이 필터는 보안 필터보다 앞이라 예외를 던져도 ApiExceptionHandler 가
+     * 잡지 못한다. 그래서 여기서 직접 JSON 을 쓴다.
+     */
+    private void reject(HttpServletResponse response, HttpStatus status, String errorCode,
+            long retryAfterSeconds) throws IOException {
 
         response.setStatus(status.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -71,7 +75,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
         response.setHeader("Retry-After", String.valueOf(retryAfterSeconds));
 
         response.getWriter().write("""
-                {"error":"%s","message":"%s","retryable":true}"""
-                .formatted(status.getReasonPhrase(), message));
+                {"error":"%s","errorCode":"%s","retryAfterSeconds":%d}"""
+                .formatted(status.getReasonPhrase(), errorCode, retryAfterSeconds));
     }
 }

--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -28,6 +28,14 @@ spring:
     # dialect 는 일부러 적지 않는다 — Boot 4/Hibernate 7 에서 MySQL8Dialect 같은
     # 버전별 이름이 제거됐다. 안 적으면 드라이버가 알아서 감지한다.
 
+  jackson:
+    serialization:
+      # 시각을 "2026-08-04T09:30:00Z" 같은 ISO 8601 문자열로 내보낸다.
+      # 켜 두면 숫자(에포크 초)로 나가서 프론트가 그대로 쓸 수 없다.
+      # Spring Boot 기본값도 false 지만, 주문 API 응답 형식이 여기에 달려 있어
+      # 나중에 누가 바꾸지 않도록 명시해 둔다.
+      write-dates-as-timestamps: false
+
 server:
   port: 60921
   tomcat:
@@ -58,6 +66,11 @@ reviewticket:
     # 발신 주소. 비우면 메일을 보내지 않고 인증 링크를 로그에 남긴다.
     # 실제 발송하려면 여기와 application-local.yml 의 spring.mail 을 채운다.
     from: ""
+  order:
+    # 주문 후 리뷰를 쓸 수 있는 기간. 지금은 개발 중이라 짧게 잡아 두었고,
+    # 마감 동작을 바로 확인할 수 있다. 실제 정책이 정해지면 이 줄만 고친다
+    # (프론트는 서버가 계산해 내려준 마감 시각을 그대로 표시한다).
+    review-ttl: 1m
   cors:
     # 쿠키를 쓰지 않고 Authorization 헤더로만 인증하므로(allowCredentials 꺼짐)
     # 출처를 전부 열어도 쿠키 기반 CSRF 같은 위험이 생기지 않는다.

--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -28,13 +28,14 @@ spring:
     # dialect 는 일부러 적지 않는다 — Boot 4/Hibernate 7 에서 MySQL8Dialect 같은
     # 버전별 이름이 제거됐다. 안 적으면 드라이버가 알아서 감지한다.
 
-  jackson:
-    serialization:
-      # 시각을 "2026-08-04T09:30:00Z" 같은 ISO 8601 문자열로 내보낸다.
-      # 켜 두면 숫자(에포크 초)로 나가서 프론트가 그대로 쓸 수 없다.
-      # Spring Boot 기본값도 false 지만, 주문 API 응답 형식이 여기에 달려 있어
-      # 나중에 누가 바꾸지 않도록 명시해 둔다.
-      write-dates-as-timestamps: false
+  # 시각 형식은 따로 설정하지 않는다.
+  #
+  # Boot 4 는 Jackson 3(tools.jackson)을 쓰는데, 거기서는 날짜를 ISO 8601
+  # 문자열로 내보내는 것이 기본이다. Jackson 2 에서 쓰던
+  # spring.jackson.serialization.write-dates-as-timestamps 는 그 자리에
+  # 더 이상 없어서, 적어 두면 기동 자체가 실패한다.
+  #
+  # 주문 API 의 시각은 Instant 로 내보내므로 "2026-08-04T09:30:00Z" 형태가 된다.
 
 server:
   port: 60921


### PR DESCRIPTION
백엔드 작업 7건을 모았습니다. 커밋 단위로 나뉘어 있어 하나씩 읽으시면 됩니다.

Closes #40
Closes #42
Closes #44
Closes #45
Closes #46
Closes #47
Closes #48

## 무엇이 들어 있나

| 커밋 | 내용 | 이슈 |
|---|---|---|
| `d70055d` | 비밀번호 재설정 페이지에 실시간 검증. 안내문을 실제 정책(6~14자)에 맞춤 | #40 |
| `bb8239a` | 가게 목록과 주문 API. 표 3개와 라우터 4개 | #42 |
| `30b410b` | 비밀번호 검사 순서를 가입 화면과 통일 | #44 |
| `db2bb12` | 429 응답에 남은 차단 시간 추가, `retryable` 제거 | #45 |
| `73a0c86` | 재설정 페이지에 요청량 제한 안내와 카운트다운 | #45 |
| `d5aab84` | 응답에서 `message` 제거하고 `errorCode` 로 통일 | #46 |
| `0fc6ab1` | DB 프로비저닝 SQL 문서를 현재 설정에 맞게 갱신 | #47 |
| `e2faf05` | 가게 생성 시 기본 메뉴 5개 함께 생성 | #48 |

## 프론트에 영향이 가는 변경

**응답에서 `message` 가 사라졌습니다.** 실패든 성공이든 마찬가지이고, `errorCode` 만 나갑니다. 지금 `shared/api/client.ts` 의 `ApiError` 가 `errorCode` 를 들고 다니지 않아 **모든 실패가 "요청을 처리하지 못했습니다" 하나로 뭉개집니다.** 이미 가입된 이메일로 가입해도 그렇게 뜹니다. 프론트 수정이 필요합니다.

**429 응답 형태가 바뀌었습니다.** `retryable` 이 없어지고 `retryAfterSeconds` 가 생겼습니다.

**가게·주문 API 가 새로 생겼습니다.** `storeApi.ts` 와 `orderApi.ts` 를 새로 만들어야 하고, `entities/store/model.ts` 와 `entities/order/model.ts` 의 타입이 응답과 맞지 않아 수정이 필요합니다(`id` 가 `string` 으로 되어 있는데 서버는 숫자로 보냅니다).

errorCode 전체 목록과 표시할 문구, 프론트 작업 목록은 `backend-integration-guide.html` 로 따로 전달했습니다.

## 머지 후 각자 해야 할 것

표 3개가 새로 생겼습니다. `ddl-auto: validate` 라 표가 없으면 서버가 뜨지 않으므로 스키마를 먼저 반영해야 합니다.

```
mysql ... --default-character-set=utf8mb4 -e "source backend/DB/08_store_menu.sql"
mysql ... --default-character-set=utf8mb4 -e "source backend/DB/09_order.sql"
```

`08` 을 먼저 실행해야 합니다. `orders` 가 `stores` 와 `menus` 를 참조합니다.

## 확인한 것

- `gradlew compileJava` 통과
- 백엔드가 만드는 HTML 페이지 두 곳을 실제로 렌더링해 `%` 이스케이프와 JS 문법 확인(`node --check`)
- 비밀번호 검증 11개 케이스를 클라이언트와 서버 양쪽에서 돌려 판정이 일치하는지 대조
- 응답에 `message` 가 남은 곳이 없는지 소스 전체 검색

브라우저에서 실제 화면 동작은 아직 확인하지 못했습니다.
