### PR TITLE
가게관리 페이지 가게명 수정 기능 + 한국어 주석 추가

### DIFF
--- a/frontend/src/pages/owner/MenuManagementPage/MenuEditModal.tsx
+++ b/frontend/src/pages/owner/MenuManagementPage/MenuEditModal.tsx
@@ -4,12 +4,13 @@ import { useAuth } from '@/app/providers';
 import { SamplePhotoStrip } from './SamplePhotoStrip';
 import type { MenuListItem as MenuListItemType } from './mockData';
 
+// FE-2.3: 메뉴 프로필 설정 / 리뷰 설정
 interface MenuEditModalProps {
   menu: MenuListItemType;
   onClose: () => void;
   onApply: (hasReviewEvent: boolean) => void;
 }
-
+// FE-2.6: 이 모달에선 이미지/가격 수정 불가가 스펙 — 버튼처럼 보여도 클릭 안 되는 게 맞음
 const lockedFieldClassName =
   'w-full cursor-not-allowed rounded-lg border border-neutral-200 bg-neutral-100 px-3 py-2 text-sm text-neutral-400';
 
@@ -18,20 +19,22 @@ export function MenuEditModal({ menu, onClose, onApply }: MenuEditModalProps) {
   const [hasReviewEvent, setHasReviewEvent] = useState(menu.hasReviewEvent);
 
   return (
+    // 모달 오버레이 — 클릭 시 닫힘 
     <div
       className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-6"
       onClick={onClose}
     >
+      {/*모달 본문 */}
       <div
         className="flex w-full max-w-2xl flex-col gap-8 rounded-2xl bg-white p-10 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         {hasReviewEvent && <SamplePhotoStrip />}
-
+        {/* 로그인한 사용자 이름(가게명) 표시 */}
         <div className="w-fit rounded-lg bg-neutral-200 px-4 py-2 text-sm font-semibold">
           {user?.displayName}
         </div>
-
+        {/* 메뉴 썸네일 + 이름/가격 + 적용 버튼 */}
         <div className="flex items-center gap-4">
           <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center rounded-lg bg-gray-200">
             <span className="text-xs text-gray-400">Image</span>
@@ -44,13 +47,13 @@ export function MenuEditModal({ menu, onClose, onApply }: MenuEditModalProps) {
             적용
           </Button>
         </div>
-
+        {/* 메뉴 설정 — 이미지/가격은 읽기 전용*/}         
         <div className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-neutral-600">메뉴 설정</span>
           
           <div className="flex items-center gap-2">
             <span className="w-25 flex-shrink-0 text-xs text-neutral-400">메뉴 이미지</span>
-            <div className={`flex-1 ${lockedFieldClassName}`}>메뉴 이미지</div>
+            <div className={`flex-1 ${lockedFieldClassName}`}>이미지 불러오기</div>
           </div>
 
           <div className="flex items-center gap-2">
@@ -60,7 +63,7 @@ export function MenuEditModal({ menu, onClose, onApply }: MenuEditModalProps) {
           </div>
            </div>
 
-
+   {/* 리뷰 이벤트 설정 — 이미지+후기 / 설정안함 선택 */}
         <div className="flex flex-col gap-2">
           <span className="text-sm font-semibold text-neutral-600">리뷰 이벤트 설정</span>
           <button

--- a/frontend/src/pages/owner/MenuManagementPage/MenuListItem.tsx
+++ b/frontend/src/pages/owner/MenuManagementPage/MenuListItem.tsx
@@ -12,6 +12,7 @@ export function MenuListItem({ menu, onClick }: MenuListItemProps) {
       onClick={onClick}
       className="flex w-full gap-4 p-4 text-left hover:bg-neutral-50"
     >
+      {/* 메뉴 이미지 자리 — 실제 이미지 없어서 placeholder */}
       <div className="flex-shrink-0">
         <div className="flex h-20 w-20 items-center justify-center rounded-lg bg-gray-200">
           <span className="text-xs text-gray-400">Image</span>
@@ -21,6 +22,7 @@ export function MenuListItem({ menu, onClick }: MenuListItemProps) {
       <div className="flex flex-1 flex-col justify-center gap-1">
         <div className="flex items-center gap-2">
           <span className="text-base font-bold">{menu.name}</span>
+          {/* 리뷰 이벤트 설정된 메뉴만 배지 표시 */}
           {menu.hasReviewEvent && (
             <span className="inline-block rounded bg-red-700 px-2 py-0.5 text-xs font-semibold text-white">
               리뷰

--- a/frontend/src/pages/owner/MenuManagementPage/MenuManagementPage.tsx
+++ b/frontend/src/pages/owner/MenuManagementPage/MenuManagementPage.tsx
@@ -6,8 +6,10 @@ import { menuItems as initialMenuItems, type MenuListItem as MenuListItemType } 
 
 export function MenuManagementPage() {
   const [menuItems, setMenuItems] = useState(initialMenuItems);
+  // 클릭한 메뉴 — 있으면 수정 모달이 열림
   const [selectedMenu, setSelectedMenu] = useState<MenuListItemType | null>(null);
 
+  // 모달의 "적용" 클릭 시: 선택된 메뉴의 리뷰이벤트 여부만 갱신하고 모달 닫기
   const handleApply = (hasReviewEvent: boolean) => {
     if (!selectedMenu) return;
     setMenuItems((items) =>
@@ -23,6 +25,7 @@ export function MenuManagementPage() {
           <h1 className="text-xl font-bold text-ink-900">메뉴관리</h1>
         </div>
         <div className="flex justify-end">
+          {/* 메뉴 추가 기능 아직 미구현 — 자리만 잡아둔 비활성 버튼 */}
           <button
             type="button"
             disabled
@@ -41,6 +44,7 @@ export function MenuManagementPage() {
         </div>
       </Card>
 
+      {/* 메뉴 클릭 시에만 수정 모달 표시 */}
       {selectedMenu && (
         <MenuEditModal
           menu={selectedMenu}

--- a/frontend/src/pages/owner/MenuManagementPage/SamplePhotoStrip.tsx
+++ b/frontend/src/pages/owner/MenuManagementPage/SamplePhotoStrip.tsx
@@ -1,5 +1,5 @@
 const SAMPLE_SLOTS = [1, 2, 3, 4, 5];
-
+// FE-2.3.1: '이미지+후기' 선택했을 때만 표본사진 5장 UI 노출
 export function SamplePhotoStrip() {
   return (
     <div className="flex w-full gap-2">

--- a/frontend/src/pages/owner/ReviewManagementPage/CompletedReviewItem.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/CompletedReviewItem.tsx
@@ -6,16 +6,19 @@ interface CompletedReviewItemProps {
 }
 
 export function CompletedReviewItem({ review }: CompletedReviewItemProps) {
+  // 서버 날짜 문자열을 한국어 표기(YYYY. M. D.)로 변환
   const date = new Date(review.createdAt).toLocaleDateString('ko-KR');
 
   return (
     <Card bordered className="flex flex-col gap-2 p-4">
       <div className="flex items-center gap-3 text-sm">
         <span className="font-semibold text-ink-900">{review.reviewerId}</span>
+        {/* 별점 숫자를 ★ 문자 반복으로 표시 */}
         <span className="text-star">{'★'.repeat(review.rating)}</span>
         <span className="text-ink-500">{date}</span>
       </div>
       <p className="text-sm text-ink-700">{review.comment}</p>
+      {/* 사진 있는 리뷰만 이미지 자리 표시 */}
       {review.photo && (
         <div className="flex h-24 w-24 items-center justify-center rounded-md bg-gray-200">
           <span className="text-xs text-gray-400">Image</span>

--- a/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
@@ -6,6 +6,7 @@ interface PendingReviewItemProps {
 }
 
 export function PendingReviewItem({ order }: PendingReviewItemProps) {
+  // 리뷰 미작성 주문 1건 카드
   return (
     <Card bordered className="flex flex-col gap-1 p-4">
       <span className="font-semibold text-ink-900">{order.ordererId}</span>

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
@@ -9,6 +9,7 @@ export function ReviewManagementPage() {
   const [activeTab, setActiveTab] = useState<ReviewTab>('completed');
 
   const totalCount = completedReviews.length;
+  // 평균 별점 — 리뷰 0개일 때 0으로 나누는 걸 막기 위해 totalCount 체크 먼저
   const averageRating =
     totalCount === 0
       ? 0
@@ -28,6 +29,7 @@ export function ReviewManagementPage() {
       <ReviewTabs active={activeTab} onChange={setActiveTab} />
 
       <div className="flex flex-col gap-3">
+        {/* activeTab에 따라 리뷰완료/리뷰미작성 리스트를 다르게 렌더링 */}
         {activeTab === 'completed'
           ? completedReviews.map((review) => (
               <CompletedReviewItem key={review.id} review={review} />

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
@@ -7,7 +7,9 @@ interface ReviewTabsProps {
 
 export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
   return (
+    // {/* 리뷰 탭 네비게이션 */} 
     <div className="flex gap-4 border-b border-neutral-200">
+      {/* 리뷰완료 탭 */} 
       <button
         type="button"
         onClick={() => onChange('completed')}
@@ -19,6 +21,7 @@ export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
       >
         리뷰완료
       </button>
+      {/* 리뷰미작성 탭 */}
       <button
         type="button"
         onClick={() => onChange('pending')}

--- a/frontend/src/pages/owner/ReviewManagementPage/StatsBar.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/StatsBar.tsx
@@ -12,6 +12,7 @@ export function StatsBar({
   pendingCount,
 }: StatsBarProps) {
   return (
+    /*총 리뷰수, 전체별점, 리뷰완료/리뷰미작성/미이행 수치 표시*/
     <div className="flex items-center justify-between rounded-lg bg-neutral-100 p-4">
       <div className="flex items-center gap-6">
         <span className="flex items-center gap-2">
@@ -22,11 +23,13 @@ export function StatsBar({
           <span className="size-2.5 rounded-full bg-red-600" />
           리뷰미작성 {pendingCount}
         </span>
+        {/* FE-2.5 값 계산 로직 미확정, 자리만 잡아둔 고정값 */}
         <span className="flex items-center gap-2">
           <span className="size-2.5 rounded-full bg-orange-500" />
           미이행 0
         </span>
       </div>
+      {/*우측 상단 총리뷰수, 전체별점 표시 */}
       <span>
         총리뷰수 {totalCount}, 전체별점 {averageRating.toFixed(1)}
       </span>

--- a/frontend/src/pages/owner/StoreManagementPage/StoreManagementPage.tsx
+++ b/frontend/src/pages/owner/StoreManagementPage/StoreManagementPage.tsx
@@ -1,8 +1,20 @@
+import { useState } from 'react';
 import { Button } from '@/shared/ui';
 import { useAuth } from '@/app/providers';
 
 export function StoreManagementPage() {
-  const { user } = useAuth();
+  const { user, updateDisplayName } = useAuth();
+  // 보기 모드 / 편집 모드 전환 플래그
+  const [isEditing, setIsEditing] = useState(false);
+  // input에 바인딩되는 임시 값 — 저장 누르기 전까진 user.displayName을 안 건드림
+  const [name, setName] = useState(user?.displayName ?? '');
+
+  // 저장 버튼 클릭 시: AuthProvider의 user.displayName을 갱신하고 편집 모드 종료
+  // (로컬 state만 바뀜, 새로고침하면 로그인 응답값으로 되돌아감 — 아직 서버 API 없음)
+  const handleSave = () => {
+    updateDisplayName(name);
+    setIsEditing(false);
+  };
 
   return (
     <div className="flex flex-col gap-4 p-6">
@@ -12,16 +24,38 @@ export function StoreManagementPage() {
         <span className="text-sm font-semibold text-neutral-600">가게 정보</span>
 
         <div className="flex items-center gap-4">
+          {/* 가게 로고 자리 — 실제 이미지 URL 없어서 회색 placeholder */}
           <div className="flex h-20 w-20 flex-shrink-0 items-center justify-center rounded-lg bg-gray-200">
             <span className="text-xs text-gray-400">가게 로고</span>
           </div>
-          <span className="flex-1 text-lg font-bold text-ink-900">{user?.displayName}</span>
-          <Button variant="secondary" size="small" disabled>
-            수정
-          </Button>
+
+          {isEditing ? (
+            <>
+              {/* 편집 모드: 가게명 입력창 */}
+              <input
+                className="flex-1 rounded border border-neutral-300 px-2 py-1 text-lg font-bold text-ink-900"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+              {/* 저장 버튼 — 클릭 시 handleSave 실행 */}
+              <Button variant="secondary" size="small" onClick={handleSave}>
+                저장
+              </Button>
+            </>
+          ) : (
+            <>
+              {/* 보기 모드: 현재 가게명 텍스트 */}
+              <span className="flex-1 text-lg font-bold text-ink-900">{user?.displayName}</span>
+              {/* 수정 버튼 — 클릭 시 편집 모드로 전환 */}
+              <Button variant="secondary" size="small" onClick={() => setIsEditing(true)}>
+                수정
+              </Button>
+            </>
+          )}
         </div>
 
         <span className="text-sm font-semibold text-neutral-600">배경 사진</span>
+        {/* 배경 사진 자리 — 아직 업로드 기능 없음, placeholder만 표시 */}
         <div className="flex h-24 w-20 items-center justify-center rounded-lg bg-gray-200">
           <span className="text-xs text-gray-400">Image</span>
         </div>

--- a/frontend/src/shared/layout/OwnerLayout/OwnerLayout.tsx
+++ b/frontend/src/shared/layout/OwnerLayout/OwnerLayout.tsx
@@ -5,6 +5,7 @@ export function OwnerLayout() {
   return (
     <div className="flex min-h-screen">
       <Sidebar />
+      {/* 자식 라우트(가게관리/메뉴관리/리뷰관리 페이지)가 여기 렌더링됨 */}
       <main className="flex-1">
         <Outlet />
       </main>

--- a/frontend/src/shared/layout/OwnerLayout/Sidebar/Sidebar.tsx
+++ b/frontend/src/shared/layout/OwnerLayout/Sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ const navLinkClassName = ({ isActive }: { isActive: boolean }) =>
 
 export function Sidebar() {
   const { user } = useAuth();
-
+// FE-2.1: 사이드바에 사장님 이름 표시, 가게관리/메뉴관리/리뷰관리 메뉴
   return (
     <aside className="flex w-65 flex-col border-r border-neutral-200 bg-neutral-50 p-4">
       <div className="mb-4 flex items-center justify-center gap-2">
@@ -19,9 +19,13 @@ export function Sidebar() {
         </div>
         <span className="flex-1 truncate font-semibold pl-2">{user?.displayName}</span>
       </div>
+      {/* 사이드바 네비게이션 메뉴 */}
       <nav className="flex flex-col gap-5 pl-4">
+        {/* /stores - 가게 목록 및 정보 관리 */}
         <NavLink to="/stores" className={navLinkClassName}>가게관리</NavLink>
+        {/* /menu - 메뉴 추가/수정/삭제 */}
         <NavLink to="/menu" className={navLinkClassName}>메뉴관리</NavLink>
+        {/* /reviews - 리뷰 확인 및 답글 관리 */}
         <NavLink to="/reviews" className={navLinkClassName}>리뷰관리</NavLink>
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- 가게관리 페이지 "수정" 버튼 활성화 — 가게명 편집 가능 (로컬 state, `useAuth().updateDisplayName` 사용, 서버 API 미연동)
- Owner 스코프 파일 전체에 한국어 설명 주석 추가 (로직 변경 없음)

## Test plan
- [ ] `npm run build` (tsc + vite build) 통과
- [ ] 실제 로그인 후 가게관리 페이지에서 수정→저장 동작 확인