### PR TITLE
[refactor] Auth 구조 개편 및 고객/사장님 로그인 플로우 개선

### DIFF
--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -22,6 +22,7 @@ export interface SignUpResponse {
 
 export interface AvailabilityResponse {
   available: boolean;
+  role?: UserRole;
 }
 
 export interface VerifiedResponse {

--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -23,12 +23,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isRestoring, setIsRestoring] = useState(() => Boolean(getToken()));
 
   useEffect(() => {
-    if (!getToken()) return;
+    if (!getToken()) {
+      console.log("[Auth] No token found, skipping session restoration");
+      return;
+    }
 
+    console.log("[Auth] Starting session restoration from stored token");
     const controller = new AbortController();
 
     getMe(controller.signal)
       .then((me) => {
+        console.log("[Auth] Session restored successfully", {
+          userId: me.userId,
+          email: me.email,
+          displayName: me.displayName,
+          role: me.role,
+        });
         setUser({
           id: me.userId,
           email: me.email,
@@ -37,32 +47,69 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           tickets: me.tickets,
         });
       })
-      .catch(() => {
+      .catch((error) => {
+        console.log("[Auth] Session restoration failed", {
+          name: error?.name,
+          message: error?.message,
+          isAborted: controller.signal.aborted,
+        });
         // 로그아웃 상태로 시작하면 그만이다. 여기서 토큰을 지우지는 않는다 —
         // 요청 취소(StrictMode 의 이중 마운트)나 일시적인 네트워크 오류까지
         // 여기로 오기 때문에, 지우면 멀쩡한 로그인이 풀린다.
         // 서버가 실제로 거부한 401 은 client.ts 가 이미 지웠다.
       })
       .finally(() => {
-        if (!controller.signal.aborted) setIsRestoring(false);
+        if (!controller.signal.aborted) {
+          console.log("[Auth] Session restoration complete, setting isRestoring to false");
+          setIsRestoring(false);
+        } else {
+          console.log("[Auth] Session restoration was aborted, keeping isRestoring as true");
+        }
       });
 
-    return () => controller.abort();
+    return () => {
+      console.log("[Auth] Cleanup: aborting session restoration request");
+      controller.abort();
+    };
   }, []);
 
   const signin = async (result: LoginResponse) => {
-    saveToken(result.token, result.expiresInSeconds);
-
-    const data = await getMe();
-
-    setUser({
-      id: data.userId,
-      email: data.email,
-      displayName: data.displayName,
-      role: data.role,
-      tickets: data.tickets,
+    console.log("[Auth] signin called", {
+      userId: result.userId,
+      displayName: result.displayName,
+      role: result.role,
     });
-    setSelectedRole(null); // 선택 상태 초기화 (계속 기억하려면 user.role)
+
+    saveToken(result.token, result.expiresInSeconds);
+    console.log("[Auth] Token saved to storage");
+
+    try {
+      console.log("[Auth] Fetching user data via getMe()");
+      const data = await getMe();
+      console.log("[Auth] getMe() succeeded", {
+        userId: data.userId,
+        email: data.email,
+        displayName: data.displayName,
+        role: data.role,
+      });
+
+      setUser({
+        id: data.userId,
+        email: data.email,
+        displayName: data.displayName,
+        role: data.role,
+        tickets: data.tickets,
+      });
+      setSelectedRole(null); // 선택 상태 초기화 (계속 기억하려면 user.role)
+      console.log("[Auth] User state updated successfully");
+    } catch (error) {
+      console.error("[Auth] getMe() failed, clearing token", {
+        name: (error as any)?.name,
+        message: (error as any)?.message,
+      });
+      clearToken();
+      throw error;
+    }
   };
 
   const signout = () => {

--- a/frontend/src/entities/user/model.ts
+++ b/frontend/src/entities/user/model.ts
@@ -31,7 +31,7 @@ export interface AuthContextType {
   /** 저장된 토큰으로 세션을 되살리는 중. 이때 로그인 화면으로 보내면 안 된다. */
   isRestoring: boolean;
 
-  signin: (result: LoginResponse, email: string) => void;
+  signin: (result: LoginResponse, email: string) => Promise<void>;
   signout: () => void;
   setSelectedRole: (role: UserRole | null) => void;
   updateDisplayName: (displayName: string) => void;

--- a/frontend/src/entities/user/model.ts
+++ b/frontend/src/entities/user/model.ts
@@ -31,7 +31,7 @@ export interface AuthContextType {
   /** 저장된 토큰으로 세션을 되살리는 중. 이때 로그인 화면으로 보내면 안 된다. */
   isRestoring: boolean;
 
-  signin: (result: LoginResponse, email: string) => Promise<void>;
+  signin: (result: LoginResponse) => Promise<void>;
   signout: () => void;
   setSelectedRole: (role: UserRole | null) => void;
   updateDisplayName: (displayName: string) => void;

--- a/frontend/src/pages/auth/EmailVerificationPage/EmailVerificationPage.tsx
+++ b/frontend/src/pages/auth/EmailVerificationPage/EmailVerificationPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation, Navigate } from "react-router-dom";
 import { Button } from "@/shared/ui";
 import { InputHelperText } from "@/shared/ui/InputHelperText";
 import { getVerificationStatus, resendVerification } from "@/api/authApi";
+import { useAuth } from "@/app/providers";
 import { ApiError } from "@/shared/api";
 import { Mail, MailCheck } from "lucide-react";
 
@@ -12,6 +13,7 @@ const STATUS_POLL_INTERVAL_MS = 5000;
 export function EmailVerificationPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { selectedRole } = useAuth();
 
   const emailParam = new URLSearchParams(location.search).get("email");
   const email = emailParam ? decodeURIComponent(emailParam) : "";
@@ -107,7 +109,16 @@ export function EmailVerificationPage() {
       </div>
 
       <div className="flex flex-col gap-2">
-        <Button fullWidth size="large" onClick={() => navigate("/login")}>
+        <Button
+          fullWidth
+          size="large"
+          onClick={() => {
+            if (selectedRole) {
+              const loginPath = selectedRole === "CUSTOMER" ? "/login/customer" : "/login/owner";
+              navigate(loginPath, { replace: true });
+            }
+          }}
+        >
           로그인하기
         </Button>
 

--- a/frontend/src/pages/auth/LoginPage/CustomerLoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/CustomerLoginPage.tsx
@@ -1,0 +1,13 @@
+import { useNavigate } from "react-router-dom";
+import { LoginForm } from "./LoginPage";
+
+export function CustomerLoginPage() {
+  const navigate = useNavigate();
+
+  const handleSuccess = () => {
+    console.log("[CustomerLoginPage] Login successful, navigating to /home");
+    navigate("/home", { replace: true });
+  };
+
+  return <LoginForm expectedRole="CUSTOMER" onSuccess={handleSuccess} />;
+}

--- a/frontend/src/pages/auth/LoginPage/ForgotPasswordModal.tsx
+++ b/frontend/src/pages/auth/LoginPage/ForgotPasswordModal.tsx
@@ -3,19 +3,26 @@ import { Modal, Button, Input } from "@/shared/ui";
 import { checkEmail, requestPasswordReset } from "@/api/authApi";
 import { validateEmail } from "@/shared/lib";
 import { ApiError } from "@/shared/api";
+import type { UserRole } from "@/entities/user";
 
 export interface ForgotPasswordModalProps {
   open: boolean;
   onClose: () => void;
+  expectedRole: UserRole;
 }
 
 /**
  * 재설정 메일만 요청한다. 실제 비밀번호 변경은 메일 링크가 여는
  * 서버 페이지(GET /api/auth/password-reset)에서 이뤄진다.
+ * expectedRole과 일치하는 이메일만 재설정 허용.
+ *
+ * 주의: 이 역할 검사는 GET /api/auth/check-email 이 role 을 함께 내려줘야 동작한다.
+ * 현재 서버 AvailabilityResponse 는 available 만 담고 있어 검사가 통과만 한다.
  */
 export function ForgotPasswordModal({
   open,
   onClose,
+  expectedRole,
 }: ForgotPasswordModalProps) {
   const [email, setEmail] = useState("");
   const [isSending, setIsSending] = useState(false);
@@ -34,6 +41,12 @@ export function ForgotPasswordModal({
       const availabilityResponse = await checkEmail(email);
       if (availabilityResponse.available) {
         setError("등록되지 않은 이메일입니다.");
+        return;
+      }
+
+      if (availabilityResponse.role && availabilityResponse.role !== expectedRole) {
+        const roleLabel = expectedRole === "CUSTOMER" ? "고객" : "사장";
+        setError(`이 이메일은 ${roleLabel}용 계정이 아닙니다.`);
         return;
       }
 

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -22,26 +22,42 @@ export function LoginPage() {
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    console.log("[Login] Form submitted", { email });
     setError("");
     setIsLoading(true);
 
     try {
+      console.log("[Login] Calling login API");
       const result = await login({
         email,
         password,
       });
+      console.log("[Login] Login API succeeded", {
+        userId: result.userId,
+        role: result.role,
+        expiresInSeconds: result.expiresInSeconds,
+      });
 
       // 로그인 응답에는 이메일이 없다. 방금 입력한 값을 그대로 쓴다.
-      signin(result, email);
+      console.log("[Login] Calling signin to restore session");
+      await signin(result, email);
+      console.log("[Login] signin completed successfully");
 
       if (result.role === "CUSTOMER") {
+        console.log("[Login] Navigating to /home");
         navigate("/home");
       }
 
       if (result.role === "OWNER") {
+        console.log("[Login] Navigating to /stores");
         navigate("/stores");
       }
     } catch (err) {
+      console.error("[Login] Login failed", {
+        name: err instanceof ApiError ? err.name : "Unknown",
+        message: err instanceof ApiError ? err.message : String(err),
+        status: err instanceof ApiError ? err.status : undefined,
+      });
       // 잠금·차단 안내는 서버 문구가 그대로 보여야 한다 (401 과 429 가 다르다).
       setError(
         err instanceof ApiError ? err.message : "로그인 정보를 확인해주세요.",

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -1,28 +1,31 @@
 import { useState } from "react";
 import { Button } from "@/shared/ui/Button";
-import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/app/providers";
 import { login } from "@/api/authApi";
 import { ApiError } from "@/shared/api";
 import { InputHelperText } from "@/shared/ui/InputHelperText";
 import { ForgotPasswordModal } from "./ForgotPasswordModal";
 import type { FormEvent } from "react";
+import type { UserRole } from "@/entities/user";
 
-export function LoginPage() {
+export interface LoginFormProps {
+  expectedRole: UserRole;
+  onSuccess: () => void;
+}
+
+export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [isForgotPasswordOpen, setIsForgotPasswordOpen] = useState(false);
 
-  const navigate = useNavigate();
-
   const { signin } = useAuth();
 
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    console.log("[Login] Form submitted", { email });
+    console.log("[Login] Form submitted", { email, expectedRole });
     setError("");
     setIsLoading(true);
 
@@ -38,27 +41,28 @@ export function LoginPage() {
         expiresInSeconds: result.expiresInSeconds,
       });
 
-      // 로그인 응답에는 이메일이 없다. 방금 입력한 값을 그대로 쓴다.
+      if (result.role !== expectedRole) {
+        console.log("[Login] Role mismatch detected", {
+          expectedRole,
+          accountRole: result.role,
+        });
+        throw new Error(
+          `이 계정은 ${expectedRole === "CUSTOMER" ? "고객" : "사장"}용 로그인이 아닙니다.`
+        );
+      }
+
       console.log("[Login] Calling signin to restore session");
-      await signin(result, email);
+      await signin(result);
       console.log("[Login] signin completed successfully");
 
-      if (result.role === "CUSTOMER") {
-        console.log("[Login] Navigating to /home");
-        navigate("/home");
-      }
-
-      if (result.role === "OWNER") {
-        console.log("[Login] Navigating to /stores");
-        navigate("/stores");
-      }
+      console.log("[Login] Calling onSuccess callback");
+      onSuccess();
     } catch (err) {
       console.error("[Login] Login failed", {
         name: err instanceof ApiError ? err.name : "Unknown",
         message: err instanceof ApiError ? err.message : String(err),
         status: err instanceof ApiError ? err.status : undefined,
       });
-      // 잠금·차단 안내는 서버 문구가 그대로 보여야 한다 (401 과 429 가 다르다).
       setError(
         err instanceof ApiError ? err.message : "로그인 정보를 확인해주세요.",
       );
@@ -119,7 +123,7 @@ export function LoginPage() {
       <div className="flex items-center justify-between">
         <button
           type="button"
-          onClick={() => navigate("/signup")}
+          onClick={() => window.location.href = "/signup"}
           className="flex-1 text-center text-sm text-ink-700 hover:text-brand-800"
         >
           회원가입하기

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/shared/ui/Button";
 import { useAuth } from "@/app/providers";
 import { login } from "@/api/authApi";
@@ -20,7 +21,15 @@ export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isForgotPasswordOpen, setIsForgotPasswordOpen] = useState(false);
 
-  const { signin } = useAuth();
+  const { signin, setSelectedRole } = useAuth();
+  const navigate = useNavigate();
+
+  // 가입 화면은 selectedRole 로 고객/사장을 구분한다. 여기서 넘겨주지 않으면
+  // SignUpPage 가 역할을 몰라 온보딩으로 되돌린다.
+  const handleGoToSignUp = () => {
+    setSelectedRole(expectedRole);
+    navigate("/signup");
+  };
 
   const handleLogin = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -47,7 +56,7 @@ export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
           accountRole: result.role,
         });
         throw new Error(
-          `이 계정은 ${expectedRole === "CUSTOMER" ? "고객" : "사장"}용 로그인이 아닙니다.`
+          `이 계정은 ${expectedRole === "CUSTOMER" ? "고객님" : "사장님"} 계정이 아닙니다.`,
         );
       }
 
@@ -64,7 +73,7 @@ export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
         status: err instanceof ApiError ? err.status : undefined,
       });
       setError(
-        err instanceof ApiError ? err.message : "로그인 정보를 확인해주세요.",
+        err instanceof Error ? err.message : "로그인 정보를 확인해주세요.",
       );
     } finally {
       setIsLoading(false);
@@ -123,7 +132,7 @@ export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
       <div className="flex items-center justify-between">
         <button
           type="button"
-          onClick={() => window.location.href = "/signup"}
+          onClick={handleGoToSignUp}
           className="flex-1 text-center text-sm text-ink-700 hover:text-brand-800"
         >
           회원가입하기
@@ -141,6 +150,7 @@ export function LoginForm({ expectedRole, onSuccess }: LoginFormProps) {
       <ForgotPasswordModal
         open={isForgotPasswordOpen}
         onClose={() => setIsForgotPasswordOpen(false)}
+        expectedRole={expectedRole}
       />
     </div>
   );

--- a/frontend/src/pages/auth/LoginPage/OwnerLoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/OwnerLoginPage.tsx
@@ -1,0 +1,13 @@
+import { useNavigate } from "react-router-dom";
+import { LoginForm } from "./LoginPage";
+
+export function OwnerLoginPage() {
+  const navigate = useNavigate();
+
+  const handleSuccess = () => {
+    console.log("[OwnerLoginPage] Login successful, navigating to /stores");
+    navigate("/stores", { replace: true });
+  };
+
+  return <LoginForm expectedRole="OWNER" onSuccess={handleSuccess} />;
+}

--- a/frontend/src/pages/auth/LoginPage/index.ts
+++ b/frontend/src/pages/auth/LoginPage/index.ts
@@ -1,1 +1,3 @@
-export { LoginPage } from './LoginPage';
+export { LoginForm } from './LoginPage';
+export { CustomerLoginPage } from './CustomerLoginPage';
+export { OwnerLoginPage } from './OwnerLoginPage';

--- a/frontend/src/pages/auth/OnboardingPage/OnboardingPage.tsx
+++ b/frontend/src/pages/auth/OnboardingPage/OnboardingPage.tsx
@@ -8,12 +8,12 @@ export function OnboardingPage() {
 
   const handleCustomerClick = () => {
     setSelectedRole("CUSTOMER");
-    navigate("/login");
+    navigate("/login/customer");
   };
 
   const handleOwnerClick = () => {
     setSelectedRole("OWNER");
-    navigate("/login");
+    navigate("/login/owner");
   };
 
   return (

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -53,11 +53,7 @@ function ProtectedRoute({
   return children;
 }
 
-function LoginRedirectRoute({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+function LoginRedirectRoute({ children }: { children: React.ReactNode }) {
   const { user, isRestoring } = useAuth();
 
   if (isRestoring) {
@@ -77,9 +73,30 @@ export function AppRoutes() {
       <Route path="/" element={<Navigate to="/onboarding" replace />} />
 
       <Route element={<AuthLayout />}>
-        <Route path="/onboarding" element={<OnboardingPage />} />
-        <Route path="/login/customer" element={<LoginRedirectRoute><CustomerLoginPage /></LoginRedirectRoute>} />
-        <Route path="/login/owner" element={<LoginRedirectRoute><OwnerLoginPage /></LoginRedirectRoute>} />
+        <Route
+          path="/onboarding"
+          element={
+            <LoginRedirectRoute>
+              <OnboardingPage />
+            </LoginRedirectRoute>
+          }
+        />
+        <Route
+          path="/login/customer"
+          element={
+            <LoginRedirectRoute>
+              <CustomerLoginPage />
+            </LoginRedirectRoute>
+          }
+        />
+        <Route
+          path="/login/owner"
+          element={
+            <LoginRedirectRoute>
+              <OwnerLoginPage />
+            </LoginRedirectRoute>
+          }
+        />
         <Route path="/signup" element={<SignUpPage />} />
         <Route path="/email-verification" element={<EmailVerificationPage />} />
       </Route>
@@ -103,7 +120,6 @@ export function AppRoutes() {
           </ProtectedRoute>
         }
       >
-
         <Route path="stores" element={<StoreManagementPage />} />
         <Route path="menu" element={<MenuManagementPage />} />
         <Route path="reviews" element={<ReviewManagementPage />} />

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,7 +9,8 @@ import {
   OrderPage,
   OrderHistoryPage,
   OnboardingPage,
-  LoginPage,
+  CustomerLoginPage,
+  OwnerLoginPage,
   SignUpPage,
   EmailVerificationPage,
   StoreManagementPage,
@@ -39,7 +40,7 @@ function ProtectedRoute({
   }
 
   if (!user) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/onboarding" replace />;
   }
 
   // 역할이 맞지 않으면 화면을 그리지 않는다. 서버도 역할을 검사해 403 으로
@@ -77,11 +78,10 @@ export function AppRoutes() {
 
       <Route element={<AuthLayout />}>
         <Route path="/onboarding" element={<OnboardingPage />} />
-        <Route path="/login" element={<LoginRedirectRoute><LoginPage /></LoginRedirectRoute>} />
+        <Route path="/login/customer" element={<LoginRedirectRoute><CustomerLoginPage /></LoginRedirectRoute>} />
+        <Route path="/login/owner" element={<LoginRedirectRoute><OwnerLoginPage /></LoginRedirectRoute>} />
         <Route path="/signup" element={<SignUpPage />} />
         <Route path="/email-verification" element={<EmailVerificationPage />} />
-        {/* <Route path="/signup/customer" element={<SignUpPage />} />
-        <Route path="/signup/owner" element={<SignUpPage />} /> */}
       </Route>
 
       <Route


### PR DESCRIPTION
## Auth 구조 개편 및 로그인 플로우 개선

기존에 고객/사장님이 함께 사용하던 로그인 및 인증 플로우를 분리.
인증 상태와 사용자 유형에 따른 라우팅을 전반적으로 개선.

### 주요 변경사항

<img width="210" height="240" alt="스크린샷 2026-08-11 164706" src="https://github.com/user-attachments/assets/3d4ecd62-da01-47f8-b9ff-2a41ce67d24e" />
<img width="210" height="240" alt="스크린샷 2026-08-11 164713" src="https://github.com/user-attachments/assets/779fb51c-8c72-4c1a-b40c-0548b3e13520" />
<img width="630" height="145" alt="image" src="https://github.com/user-attachments/assets/9edc9d03-f109-4666-bcb2-b655b41515c3" />


- 고객/사장님 로그인 페이지 분리
  - 사용자 유형별 로그인 페이지 및 URL 분리
  - 로그인 플로우를 사용자 유형에 맞게 명확하게 구분
- Auth 상태 및 인증 플로우 전반적인 리팩토링
- 최초 API 요청에서 `fetch failed` 발생 후 재요청 시 정상 응답되는 케이스 수정
- 로그인 후 뒤로가기 시 온보딩 화면으로 이동하는 문제 수정
- 온보딩에서 선택한 사용자 유형과 실제 로그인 사용자 유형이 일치하지 않는 문제 수정
- 사용자 유형에 따라 올바른 로그인/인증 플로우가 진행되도록 개선

### 결과

고객/사장님 인증 플로우를 명확하게 분리하고,
온보딩 → 로그인 → 인증 상태 → 페이지 이동까지의 흐름을 안정적으로 개선

비밀번호 재설정 기능도 구현. 백엔드에서 api 수정하면 정상적으로 실행
