### PR TITLE
fix: 비밀번호 찾기 role 불일치 처리 + AI 실험 폴더명 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Claude Code 세션 변경 로그 (자동 생성)
 _CHANGES.md
+
+# DINOv2 로컬 실험 (venv·데이터셋 포함, 용량 커서 git 미포함)
+ai/dinov2-test/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# ReviewTicketFullstack

--- a/ai/README.md
+++ b/ai/README.md
@@ -25,7 +25,7 @@ DINOv2는 이미지 자체의 시각적 유사도 판별에 특화된 자기지�
 테스트에서 간격이 0.404까지 벌어졌다. 상세 테스트 결과와 근거는 아래 참고.
 
 - 테스트 결과 리포트: https://claude.ai/code/artifact/2ef2d3bb-055c-4a4c-b045-48ee0bf7070e
-- 테스트 스크립트: `clip-test/eval_menu_match_v2.py` (로컬 전용, git 미포함 - 데이터셋 용량 커서 커밋 안 함)
+- 테스트 스크립트: `dinov2-test/eval_menu_match_v2.py` (로컬 전용, git 미포함 - 데이터셋 용량 커서 커밋 안 함)
 
 ## 백엔드 연결
 
@@ -36,11 +36,11 @@ DINOv2는 이미지 자체의 시각적 유사도 판별에 특화된 자기지�
 기동:
 
 ```
-C:\dev\ReviewTicketFullstack\ai\clip-test\.venv\Scripts\python.exe -m pip install -r server\requirements.txt
-C:\dev\ReviewTicketFullstack\ai\clip-test\.venv\Scripts\python.exe -m uvicorn main:app --port 8000 --app-dir server
+C:\dev\ReviewTicketFullstack\ai\dinov2-test\.venv\Scripts\python.exe -m pip install -r server\requirements.txt
+C:\dev\ReviewTicketFullstack\ai\dinov2-test\.venv\Scripts\python.exe -m uvicorn main:app --port 8000 --app-dir server
 ```
 
-별도 venv 를 새로 안 만들고 `clip-test/.venv`를 그대로 쓴다 — torch·transformers가
+별도 venv 를 새로 안 만들고 `dinov2-test/.venv`를 그대로 쓴다 — torch·transformers가
 이미 설치돼 있어서 fastapi/uvicorn/python-multipart 세 개만 추가로 깔면 된다.
 
 백엔드(`application.yml` 의 `reviewticket.ai.server-url`) 기본값이 이미

--- a/ai/server/main.py
+++ b/ai/server/main.py
@@ -6,8 +6,8 @@ DINOv2 임베딩의 코사인 유사도를 계산해 돌려준다. 0.80 문턱�
 판정)는 이 서버가 아니라 백엔드가 한다 — 여기는 숫자 하나만 책임진다.
 
 기동:
-    C:\\dev\\ReviewTicketFullstack\\ai\\clip-test\\.venv\\Scripts\\python.exe -m uvicorn main:app --port 8000
-    (별도 venv 를 새로 만들지 않고 clip-test 의 venv 를 그대로 쓴다 — torch·
+    C:\\dev\\ReviewTicketFullstack\\ai\\dinov2-test\\.venv\\Scripts\\python.exe -m uvicorn main:app --port 8000
+    (별도 venv 를 새로 만들지 않고 dinov2-test 의 venv 를 그대로 쓴다 — torch·
     transformers 가 이미 설치돼 있다. fastapi/uvicorn/python-multipart 만
     추가로 설치하면 된다: requirements.txt 참고)
 

--- a/ai/server/requirements.txt
+++ b/ai/server/requirements.txt
@@ -1,8 +1,8 @@
-# clip-test/.venv 에 이미 torch·transformers·pillow·numpy 가 설치돼 있다.
+# dinov2-test/.venv 에 이미 torch·transformers·pillow·numpy 가 설치돼 있다.
 # 이 서버를 돌리는 데 추가로 필요한 건 아래 세 개뿐이다.
 #
 # 설치:
-#   C:\dev\ReviewTicketFullstack\ai\clip-test\.venv\Scripts\python.exe -m pip install -r requirements.txt
+#   C:\dev\ReviewTicketFullstack\ai\dinov2-test\.venv\Scripts\python.exe -m pip install -r requirements.txt
 
 fastapi>=0.115
 uvicorn[standard]>=0.32

--- a/backend/Server/.gitignore
+++ b/backend/Server/.gitignore
@@ -1,7 +1,7 @@
 ### ReviewTicket ###
-# 업로드된 리뷰 사진. 코드 폴더 안에 있지만 저장소에 올리지 않는다.
-Uploaded_pictures/
-!Uploaded_pictures/.gitkeep
+# 업로드된 리뷰·메뉴 사진. 코드 폴더 안에 있지만 저장소에 올리지 않는다.
+uploads/
+!uploads/.gitkeep
 # DB 접속 비밀번호가 들어간다
 src/main/resources/application-local.yml
 

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthController.java
@@ -80,7 +80,9 @@ public class AuthController {
     public record VerifyResponse(String email) {
     }
 
-    public record ResetRequest(@Email(message = "이메일 형식이 올바르지 않습니다") @NotBlank String email) {
+    public record ResetRequest(
+            @Email(message = "이메일 형식이 올바르지 않습니다") @NotBlank String email,
+            @NotNull(message = "역할이 없습니다") Role role) {
     }
 
     public record ResetTokenResponse(boolean valid) {
@@ -170,13 +172,13 @@ public class AuthController {
      * 원래는 계정 열거 방지를 위해 존재 여부와 무관하게 항상 같은 응답을
      * 줬는데, "가입되지 않은 이메일입니다" 를 화면에 보여주는 UX 를 위해
      * 의도적으로 그 방어를 풀기로 했다(제품 결정, 2026-08-04).
+     *
+     * 이메일이 아예 없는 경우(NO_EXISTING_EMAIL)와 이메일은 있지만 role 이
+     * 다른 계정인 경우(ROLE_MISMATCH)는 authService 가 구분해서 던진다.
      */
     @PostMapping(value = "/password-reset/request", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResetRequestResponse requestPasswordReset(@Valid @RequestBody ResetRequest request) {
-        boolean exists = authService.requestPasswordReset(request.email());
-        if (!exists) {
-            throw new ValidationException("NO_EXISTING_EMAIL", "가입되지 않은 이메일입니다");
-        }
+        authService.requestPasswordReset(request.email(), request.role());
         return new ResetRequestResponse("YES_EXISTING_EMAIL");
     }
 

--- a/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/auth/AuthService.java
@@ -277,32 +277,32 @@ public class AuthService {
      * 존재 여부를 이제 그대로 알려준다(제품 결정, 2026-08-04) — 열거 방지보다
      * "가입되지 않은 이메일입니다" 라는 UX 를 우선하기로 했다.
      *
-     * @return 그 이메일로 가입된 회원이 있었는지
+     * role 도 함께 확인한다. 이메일 자체가 없는 경우와, 이메일은 있지만 role
+     * 이 다른 계정인 경우를 구분해서 던진다 — 온보딩에서 역할 카드를 잘못
+     * 고른 본인에게 "이메일이 아예 없다"고 오인시키지 않기 위해서다.
      */
     @Transactional
-    public boolean requestPasswordReset(String rawEmail) {
-        Optional<User> found = users.findByEmail(normalizeEmail(rawEmail));
-        if (found.isEmpty()) {
-            return false;
+    public void requestPasswordReset(String rawEmail, Role role) {
+        User user = users.findByEmail(normalizeEmail(rawEmail))
+                .orElseThrow(() -> new ValidationException("NO_EXISTING_EMAIL", "가입되지 않은 이메일입니다"));
+        if (user.getRole() != role) {
+            throw new ValidationException("ROLE_MISMATCH", "계정의 역할에 맞지 않는 접근 시도입니다");
         }
-        User user = found.get();
 
-        // 재발송 간격 제한. 쿨다운이면 메일만 다시 안 보내고 조용히 끝낸다 —
-        // 계정은 실제로 존재하므로 존재 여부 응답(true)은 그대로 준다.
+        // 재발송 간격 제한. 쿨다운이면 메일만 다시 안 보내고 조용히 끝낸다.
         boolean recentlySent = resetTokens.findTopByUserOrderByIdDesc(user)
                 .map(PasswordResetToken::getCreatedAt)
                 .map(createdAt -> createdAt != null
                         && createdAt.isAfter(LocalDateTime.now().minus(RESEND_COOLDOWN)))
                 .orElse(false);
         if (recentlySent) {
-            return true;
+            return;
         }
 
         String token = newToken();
         resetTokens.save(new PasswordResetToken(
                 user, token, LocalDateTime.now().plus(properties.auth().verificationTtl())));
         events.publishEvent(new PasswordResetMailRequested(user.getEmail(), token));
-        return true;
     }
 
     /**

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -82,9 +82,12 @@ export function resendVerification(email: string): Promise<MessageResponse> {
 }
 
 /** 가입되지 않은 이메일이어도 항상 성공한다 — 가입 여부가 새어나가지 않게 하려는 설계다. */
-export function requestPasswordReset(email: string): Promise<MessageResponse> {
+export function requestPasswordReset(
+  email: string,
+  role: UserRole,
+): Promise<MessageResponse> {
   return request<MessageResponse>("/auth/password-reset/request", {
     method: "POST",
-    body: { email },
+    body: { email, role },
   });
 }

--- a/frontend/src/pages/auth/LoginPage/ForgotPasswordModal.tsx
+++ b/frontend/src/pages/auth/LoginPage/ForgotPasswordModal.tsx
@@ -3,10 +3,30 @@ import { Modal, Button, Input } from "@/shared/ui";
 import { checkEmail, requestPasswordReset } from "@/api/authApi";
 import { validateEmail } from "@/shared/lib";
 import { ApiError } from "@/shared/api";
+import { useAuth } from "@/app/providers";
 
 export interface ForgotPasswordModalProps {
   open: boolean;
   onClose: () => void;
+}
+
+/**
+ * 서버는 errorCode 만 보내고 문구는 화면이 채운다.
+ * NO_EXISTING_EMAIL(이메일 자체가 없음)과 ROLE_MISMATCH(이메일은 있지만
+ * 다른 role 계정)를 구분해서, 역할 카드를 잘못 고른 본인이 "이메일이
+ * 아예 없다"고 오인하지 않게 한다.
+ */
+function toMessage(error: unknown): string {
+  if (!(error instanceof ApiError)) return "재설정 메일을 보내지 못했습니다.";
+
+  switch (error.errorCode) {
+    case "NO_EXISTING_EMAIL":
+      return "등록되지 않은 이메일입니다.";
+    case "ROLE_MISMATCH":
+      return "계정의 역할에 맞지 않는 접근 시도입니다.";
+    default:
+      return error.message;
+  }
 }
 
 /**
@@ -19,26 +39,34 @@ export function ForgotPasswordModal({ open, onClose }: ForgotPasswordModalProps)
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
+  const { selectedRole } = useAuth();
+
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!validateEmail(email) || isSending) return;
+
+    if (!selectedRole) {
+      setError("어느 계정으로 찾을지 알 수 없어요. 처음 화면부터 다시 시작해 주세요.");
+      return;
+    }
 
     setIsSending(true);
     setError("");
 
     try {
+      // checkEmail 은 role 을 가리지 않고 존재 여부만 본다 — role 이 다른
+      // 계정으로 가입된 이메일은 여기선 안 걸러지고, requestPasswordReset 이
+      // role 까지 맞춰 조회하며 최종적으로 막는다.
       const availabilityResponse = await checkEmail(email);
       if (availabilityResponse.available) {
         setError("등록되지 않은 이메일입니다.");
         return;
       }
 
-      const response = await requestPasswordReset(email);
+      const response = await requestPasswordReset(email, selectedRole);
       setMessage(response.message);
     } catch (err) {
-      setError(
-        err instanceof ApiError ? err.message : "재설정 메일을 보내지 못했습니다.",
-      );
+      setError(toMessage(err));
     } finally {
       setIsSending(false);
     }

--- a/frontend/src/pages/customer/MyInfoModal/MyInfoModal.tsx
+++ b/frontend/src/pages/customer/MyInfoModal/MyInfoModal.tsx
@@ -93,7 +93,7 @@ export function MyInfoModal({ open, onClose }: MyInfoModalProps) {
     setPasswordMessage("");
 
     try {
-      const response = await requestPasswordReset(user.email);
+      const response = await requestPasswordReset(user.email, user.role);
       setPasswordMessage(response.message);
     } catch (error) {
       setPasswordMessage(


### PR DESCRIPTION
## 요약
- 비밀번호 찾기 요청에 role이 안 실려서, 온보딩에서 역할을 잘못 고르면 자기 계정인데도 "등록되지 않은 이메일"로 오인하게 되던 문제 수정 (#102)
- `ai/clip-test` 폴더가 실제 사용 모델(DINOv2)과 이름이 안 맞던 것을 `ai/dinov2-test`로 정리, 관련 문서 경로 갱신

## 커밋
- `docs: AI 실험 폴더 clip-test -> dinov2-test 이름 정리`
- `fix: 비밀번호 찾기가 role 무관하게 이메일만으로 계정을 찾던 문제 (#102)`

## 테스트
- [x] 프론트 `tsc -b --noEmit` 통과
- [x] 백엔드 `gradlew compileJava` 통과
- [x] 로컬에서 온보딩→role 잘못 선택→비밀번호 찾기 시나리오 직접 확인 (ROLE_MISMATCH 문구 정상 표시)

Closes #102