### PR TITLE
[feat] 리뷰관리 미이행 탭 추가

### DIFF
--- a/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Card } from '@/shared/ui';
 import type { PendingOrder } from '@/api/reviewApi';
 import { OrderItemBox } from './OrderItemBox';
@@ -9,9 +9,21 @@ import {
 
 interface PendingReviewItemProps {
   order: PendingOrder;
+  /**
+   * 마감을 막 넘긴 순간 한 번 불린다. 목록을 다시 받아야 이 주문이 미이행으로
+   * 옮겨간다 — reviewStatus 는 서버가 조회 시점에 판정한 값이라 화면에 머무는
+   * 동안에는 바뀌지 않는다.
+   *
+   * 참조가 고정된 함수를 넘겨야 한다. 매 렌더 새로 만든 함수를 넘기면 아래
+   * effect 가 다시 돌아 interval 이 계속 버려지고 만들어진다.
+   */
+  onExpire?: () => void;
 }
 
-export function PendingReviewItem({ order }: PendingReviewItemProps) {
+export function PendingReviewItem({
+  order,
+  onExpire,
+}: PendingReviewItemProps) {
   // 리뷰 미작성 주문 1건 카드
   // 주문일자를 한국어 표기로 변환 (CompletedReviewItem과 동일한 포맷)
   const date = new Date(order.orderedAt).toLocaleDateString('ko-KR');
@@ -22,14 +34,24 @@ export function PendingReviewItem({ order }: PendingReviewItemProps) {
     getRemainingReviewTime(order.expireTime),
   );
 
+  // 한 카드가 재조회를 여러 번 부르지 않게 막는다.
+  const hasFiredExpire = useRef(false);
+
   useEffect(() => {
     if (!isPending) return;
     // 손님쪽 ReviewButton 과 같은 주기다. 1초로 두면 초 표시가 가끔 건너뛴다.
     const interval = setInterval(() => {
-      setRemaining(getRemainingReviewTime(order.expireTime));
+      const left = getRemainingReviewTime(order.expireTime);
+      setRemaining(left);
+
+      if (left <= 0 && !hasFiredExpire.current) {
+        hasFiredExpire.current = true;
+        clearInterval(interval);
+        onExpire?.();
+      }
     }, 300);
     return () => clearInterval(interval);
-  }, [isPending, order.expireTime]);
+  }, [isPending, order.expireTime, onExpire]);
 
   return (
     <Card bordered className="flex flex-col gap-3 p-4">

--- a/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/PendingReviewItem.tsx
@@ -1,6 +1,11 @@
+import { useEffect, useState } from 'react';
 import { Card } from '@/shared/ui';
 import type { PendingOrder } from '@/api/reviewApi';
 import { OrderItemBox } from './OrderItemBox';
+import {
+  getRemainingReviewTime,
+  formatTimeRemaining,
+} from '@/entities/order/reviewTime';
 
 interface PendingReviewItemProps {
   order: PendingOrder;
@@ -11,11 +16,31 @@ export function PendingReviewItem({ order }: PendingReviewItemProps) {
   // 주문일자를 한국어 표기로 변환 (CompletedReviewItem과 동일한 포맷)
   const date = new Date(order.orderedAt).toLocaleDateString('ko-KR');
 
+  // 작성 대기 카드만 카운트다운을 돈다. 미이행은 이미 마감이라 셀 것이 없다.
+  const isPending = order.reviewStatus === 'pending';
+  const [remaining, setRemaining] = useState(() =>
+    getRemainingReviewTime(order.expireTime),
+  );
+
+  useEffect(() => {
+    if (!isPending) return;
+    // 손님쪽 ReviewButton 과 같은 주기다. 1초로 두면 초 표시가 가끔 건너뛴다.
+    const interval = setInterval(() => {
+      setRemaining(getRemainingReviewTime(order.expireTime));
+    }, 300);
+    return () => clearInterval(interval);
+  }, [isPending, order.expireTime]);
+
   return (
     <Card bordered className="flex flex-col gap-3 p-4">
       <div className="flex items-center gap-3 text-sm">
         <span className="font-semibold text-ink-900">{order.displayName}</span>
         <span className="text-ink-500">{date}</span>
+        {isPending && (
+          <span className="ml-auto font-semibold text-orange-600">
+            {remaining > 0 ? `${formatTimeRemaining(remaining)} 남음` : '마감'}
+          </span>
+        )}
       </div>
       {/* 주문한 메뉴/가격. 이 목록은 이벤트 참여 주문만 담고 있다 */}
       <OrderItemBox

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
@@ -45,6 +45,11 @@ export function ReviewManagementPage() {
     return () => controller.abort();
   }, []);
 
+  // 서버는 둘을 한 목록에 담아 보낸다(GET /api/stores/me/orders/pending).
+  // 마감 전이면 작성 대기, 마감이 지났는데도 리뷰가 없으면 미이행.
+  const pendingList = pendingOrders.filter((o) => o.reviewStatus === 'pending');
+  const expiredList = pendingOrders.filter((o) => o.reviewStatus === 'expired');
+
   return (
     <div className="flex flex-col gap-4 p-6">
       <h1 className="text-xl font-bold text-ink-900">리뷰관리</h1>
@@ -53,7 +58,8 @@ export function ReviewManagementPage() {
         totalCount={totalCount}
         averageRating={averageRating}
         completedCount={completedReviews.length}
-        pendingCount={pendingOrders.length}
+        pendingCount={pendingList.length}
+        expiredCount={expiredList.length}
       />
 
       <ReviewTabs active={activeTab} onChange={setActiveTab} />
@@ -62,12 +68,12 @@ export function ReviewManagementPage() {
       {error && <p className="text-sm text-red-600">{error}</p>}
 
       <div className="flex flex-col gap-3">
-        {/* activeTab에 따라 리뷰완료/리뷰미작성 리스트를 다르게 렌더링 */}
+        {/* activeTab에 따라 리뷰완료/작성 대기/미이행 리스트를 다르게 렌더링 */}
         {activeTab === 'completed'
           ? completedReviews.map((review) => (
               <CompletedReviewItem key={review.reviewId} review={review} />
             ))
-          : pendingOrders.map((order) => (
+          : (activeTab === 'pending' ? pendingList : expiredList).map((order) => (
               <PendingReviewItem key={order.orderId} order={order} />
             ))}
       </div>

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { StatsBar } from './StatsBar';
 import { ReviewTabs, type ReviewTab } from './ReviewTabs';
 import { CompletedReviewItem } from './CompletedReviewItem';
@@ -20,8 +20,12 @@ export function ReviewManagementPage() {
   const [averageRating, setAverageRating] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  // 값이 바뀌면 아래 useEffect 가 다시 돈다. 새로고침 버튼이 이 값을 올린다.
+  // 값이 바뀌면 아래 useEffect 가 다시 돈다. 새로고침 버튼과 카드 만료가 올린다.
   const [reloadKey, setReloadKey] = useState(0);
+
+  // 카드에 넘기는 값이라 참조가 고정돼야 한다. 인라인 화살표로 넘기면 매 렌더마다
+  // 새 함수가 돼 카드의 카운트다운 interval 이 계속 버려지고 다시 만들어진다.
+  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -69,7 +73,7 @@ export function ReviewManagementPage() {
       <ReviewTabs
         active={activeTab}
         onChange={setActiveTab}
-        onRefresh={() => setReloadKey((k) => k + 1)}
+        onRefresh={reload}
         isRefreshing={isLoading}
       />
 
@@ -83,7 +87,11 @@ export function ReviewManagementPage() {
               <CompletedReviewItem key={review.reviewId} review={review} />
             ))
           : (activeTab === 'pending' ? pendingList : expiredList).map((order) => (
-              <PendingReviewItem key={order.orderId} order={order} />
+              <PendingReviewItem
+                key={order.orderId}
+                order={order}
+                onExpire={reload}
+              />
             ))}
       </div>
     </div>

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
@@ -20,9 +20,13 @@ export function ReviewManagementPage() {
   const [averageRating, setAverageRating] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // 값이 바뀌면 아래 useEffect 가 다시 돈다. 새로고침 버튼이 이 값을 올린다.
+  const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
 
     Promise.all([
       getMyStoreReviews(controller.signal),
@@ -43,7 +47,7 @@ export function ReviewManagementPage() {
       });
 
     return () => controller.abort();
-  }, []);
+  }, [reloadKey]);
 
   // 서버는 둘을 한 목록에 담아 보낸다(GET /api/stores/me/orders/pending).
   // 마감 전이면 작성 대기, 마감이 지났는데도 리뷰가 없으면 미이행.
@@ -62,7 +66,12 @@ export function ReviewManagementPage() {
         expiredCount={expiredList.length}
       />
 
-      <ReviewTabs active={activeTab} onChange={setActiveTab} />
+      <ReviewTabs
+        active={activeTab}
+        onChange={setActiveTab}
+        onRefresh={() => setReloadKey((k) => k + 1)}
+        isRefreshing={isLoading}
+      />
 
       {isLoading && <p className="text-sm text-neutral-500">불러오는 중...</p>}
       {error && <p className="text-sm text-red-600">{error}</p>}

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
@@ -1,4 +1,4 @@
-export type ReviewTab = 'completed' | 'pending';
+export type ReviewTab = 'completed' | 'pending' | 'expired';
 
 interface ReviewTabsProps {
   active: ReviewTab;
@@ -21,7 +21,19 @@ export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
       >
         리뷰완료
       </button>
-      {/* 리뷰미작성 탭 */}
+      {/* 미이행 탭 — 리뷰 기한이 지나버린 주문 */}
+      <button
+        type="button"
+        onClick={() => onChange('expired')}
+        className={
+          active === 'expired'
+            ? 'border-b-2 border-brand-800 pb-2 font-bold text-brand-800'
+            : 'pb-2 text-neutral-500'
+        }
+      >
+        미이행
+      </button>
+      {/* 작성 대기 탭 — 마감 전이라 아직 리뷰가 들어올 수 있다 */}
       <button
         type="button"
         onClick={() => onChange('pending')}
@@ -31,7 +43,7 @@ export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
             : 'pb-2 text-neutral-500'
         }
       >
-        리뷰미작성
+        작성 대기
       </button>
     </div>
   );

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewTabs.tsx
@@ -1,11 +1,20 @@
+import { RotateCw } from 'lucide-react';
+
 export type ReviewTab = 'completed' | 'pending' | 'expired';
 
 interface ReviewTabsProps {
   active: ReviewTab;
   onChange: (tab: ReviewTab) => void;
+  onRefresh: () => void;
+  isRefreshing?: boolean;
 }
 
-export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
+export function ReviewTabs({
+  active,
+  onChange,
+  onRefresh,
+  isRefreshing = false,
+}: ReviewTabsProps) {
   return (
     // {/* 리뷰 탭 네비게이션 */} 
     <div className="flex gap-4 border-b border-neutral-200">
@@ -44,6 +53,17 @@ export function ReviewTabs({ active, onChange }: ReviewTabsProps) {
         }
       >
         작성 대기
+      </button>
+      {/* 목록·개수를 다시 받아온다. 마감이 지나 미이행으로 넘어간 건은
+          재조회해야 탭이 옮겨간다 */}
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={isRefreshing}
+        aria-label="새로고침"
+        className="ml-auto flex size-8 items-center justify-center rounded-lg text-neutral-500 hover:bg-neutral-100 disabled:opacity-50"
+      >
+        <RotateCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
       </button>
     </div>
   );

--- a/frontend/src/pages/owner/ReviewManagementPage/StatsBar.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/StatsBar.tsx
@@ -3,6 +3,7 @@ interface StatsBarProps {
   averageRating: number;
   completedCount: number;
   pendingCount: number;
+  expiredCount: number;
 }
 
 export function StatsBar({
@@ -10,9 +11,10 @@ export function StatsBar({
   averageRating,
   completedCount,
   pendingCount,
+  expiredCount,
 }: StatsBarProps) {
   return (
-    /*총 리뷰수, 전체별점, 리뷰완료/리뷰미작성/미이행 수치 표시*/
+    /*총 리뷰수, 전체별점, 리뷰완료/작성 대기/미이행 수치 표시*/
     <div className="flex items-center justify-between rounded-lg bg-neutral-100 p-4">
       <div className="flex items-center gap-6">
         <span className="flex items-center gap-2">
@@ -21,12 +23,11 @@ export function StatsBar({
         </span>
         <span className="flex items-center gap-2">
           <span className="size-2.5 rounded-full bg-red-600" />
-          리뷰미작성 {pendingCount}
+          미이행 {expiredCount}
         </span>
-        {/* FE-2.5 값 계산 로직 미확정, 자리만 잡아둔 고정값 */}
         <span className="flex items-center gap-2">
           <span className="size-2.5 rounded-full bg-orange-500" />
-          미이행 0
+          작성 대기 {pendingCount}
         </span>
       </div>
       {/*우측 상단 총리뷰수, 전체별점(별 아이콘+평균) 표시 */}


### PR DESCRIPTION
## 요약 :
[feature] 사장 페이지 -> 리뷰관리에 **미이행** 탭 추가. 마감이 지났는데 리뷰가 안 온 주문을 따로 봅니다
[feature] 작성 대기 카드에 마감까지 **남은 시간 카운트다운** 표시, 0이 되면 목록 자동 재조회
[feature] 탭 줄 오른쪽 끝 **새로고침 버튼** — 페이지를 다시 안 띄워도 개수·목록이 갱신됩니다
[fix] `리뷰미작성` 탭 개수가 실제보다 부풀려 나오던 문제 수정

프론트만 바뀌었고 서버·API 변경은 없습니다. 받아서 바로 확인 가능합니다.

## 배경

리뷰관리에 리뷰완료 / 리뷰미작성 두 탭만 있고 미이행 탭이 없었다.

서버는 이미 두 종류를 다 내려주고 있었다.

```
GET /api/stores/me/orders/pending
      ↓
ReviewService  o.isExpired(now) ? "expired" : "pending"
      ↓
한 배열에 섞어서 응답
      ↓
프론트가 reviewStatus 를 어디서도 안 읽는다  ← 여기
      ↓
배열 전체를 "리뷰미작성" 으로 그림 = 목록도 개수도 두 종류가 섞임
```

즉 미이행은 만들 데이터가 없어서 빠진 게 아니라, 받아 놓고 안 쓰고 있었다.
`filter` 두 줄이 목록과 개수를 한 번에 갈라놓는다 — 상단 개수도 같은 배열에서
나오던 값이라 따로 고칠 게 없었다.

## 만든 것

- **미이행 탭.** `reviewStatus` 로 목록을 나눈다. 탭 순서는 리뷰완료 / 미이행 / 작성 대기
- **`리뷰미작성` → `작성 대기` 로 이름 변경.** 둘 다 "리뷰를 안 썼다"는 뜻이라 어느
  쪽이 마감 전인지 이름만 봐선 알 수 없었다. 명세에 있는 용어인 미이행은 그대로 두고
  헷갈리는 쪽을 바꿨다
- **작성 대기 카드에 `MM:SS 남음` 카운트다운.** 손님쪽 `ReviewButton` 이 쓰는
  `reviewTime.ts` 를 그대로 재사용했다. 미이행 카드는 이미 마감이라 안 돈다
- **새로고침 버튼** (`RotateCw`, 돌아가는 중엔 `animate-spin` + disabled)

## 그 과정에서 함께 고친 것 — 시계가 두 개였다

상단 개수는 **서버가 조회 시점에 판정한** `reviewStatus` 로 세고, 카드의 "마감"
문구는 **브라우저 타이머**로 판단한다. 화면을 켜 둔 채 마감을 넘기면 두 값이
갈라져서, `작성 대기 1건` 인데 그 1건이 "마감" 이라고 적힌 상태가 된다.

카드가 0에 닿는 순간 딱 한 번 부모에게 알리고, 부모가 목록을 다시 받아 서버가
새로 판정하게 했다. 카드는 그때 미이행 탭으로 옮겨간다.

이때 부모가 넘기는 콜백은 `useCallback` 으로 참조를 고정했다. 인라인 화살표로
넘기면 카드가 300ms 마다 리렌더될 때마다 새 함수가 되고, `useEffect` 의존성이
바뀌어 카운트다운 `interval` 이 초당 세 번씩 버려졌다 다시 만들어진다.

## Test plan

- [x] `npx tsc -b --force` exit 0 / `npx oxlint` 신규 error 0
- [x] 사장 계정 → 리뷰관리. 세 탭의 목록·개수가 서로 안 겹침
- [x] 작성 대기 카드에 `MM:SS 남음` 표시, 실시간으로 줄어듦
- [x] 켜 둔 채로 마감을 넘기면 그 카드가 저절로 미이행 탭으로 넘어감
- [x] 새로고침 버튼 → 아이콘 회전, 개수 갱신. 누르는 동안 중복 클릭 안 됨
- [x] 리뷰완료 탭은 기존과 동일하게 동작

## 참고

`dev` 를 두 번 받아왔고 충돌 없이 붙었다. 건드린 파일이
`pages/owner/ReviewManagementPage/` 아래 4개뿐이라 다른 분들 작업과 안 겹친다.
