### PR TITLE
[fix] customer 홈 리뷰 뱃지 조건 누락, 헤더 티켓 개수 미갱신 수정

### DIFF
--- a/frontend/src/app/providers/AuthProvider.tsx
+++ b/frontend/src/app/providers/AuthProvider.tsx
@@ -122,6 +122,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser((current) => (current ? { ...current, displayName } : current));
   };
 
+  const updateTickets = (tickets: number) => {
+    setUser((current) => (current ? { ...current, tickets } : current));
+  };
+
   return (
     <AuthContext.Provider
       value={{
@@ -132,6 +136,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         signin,
         signout,
         updateDisplayName,
+        updateTickets,
       }}
     >
       {children}

--- a/frontend/src/entities/user/model.ts
+++ b/frontend/src/entities/user/model.ts
@@ -35,4 +35,6 @@ export interface AuthContextType {
   signout: () => void;
   setSelectedRole: (role: UserRole | null) => void;
   updateDisplayName: (displayName: string) => void;
+  /** 주문,리뷰 응답에 실려 온 잔여 티켓으로 상단 뱃지 갱신 */
+  updateTickets: (tickets: number) => void;
 }

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -127,6 +127,7 @@ export function HomePage() {
             rating={store.rating}
             reviewCount={store.reviewCount.toString()}
             imageUrl={store.imageUrl}
+            hasReviewEvent={store.hasReviewEvent}
           />
         ))}
       </div>

--- a/frontend/src/pages/customer/HomePage/StoreCard.tsx
+++ b/frontend/src/pages/customer/HomePage/StoreCard.tsx
@@ -8,6 +8,8 @@ export interface StoreCardProps {
   rating: number;
   reviewCount: string;
   imageUrl: string | null;
+  // 리뷰 작성 가능 메뉴가 하나라도 있을때 true - 리뷰 뱃지 노출 조건
+  hasReviewEvent: boolean;
 }
 
 export function StoreCard({
@@ -16,6 +18,7 @@ export function StoreCard({
   rating,
   reviewCount,
   imageUrl,
+  hasReviewEvent,
 }: StoreCardProps) {
   const navigate = useNavigate();
 
@@ -50,9 +53,11 @@ export function StoreCard({
         {/* First Row: Store Name + Review Chip */}
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-bold">{storeName}</h3>
-          <div className="bg-red-700 text-white px-2 py-1 rounded text-xs font-semibold">
-            리뷰
-          </div>
+          {hasReviewEvent && (
+            <div className="bg-red-700 text-white px-2 py-1 rounded text-xs font-semibold">
+              리뷰
+            </div>
+          )}
         </div>
 
         {/* Second Row: Rating Info */}

--- a/frontend/src/pages/customer/OrderHistoryPage/ReviewModal.tsx
+++ b/frontend/src/pages/customer/OrderHistoryPage/ReviewModal.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/shared/ui';
 import { Modal } from '@/shared/ui/Modal/Modal';
 import { useCameraCapture } from '@/shared/hooks';
 import { createReview } from '@/api/reviewApi';
+import { useAuth } from '@/app/providers';
 import { ApiError } from '@/shared/api';
 import type { ID } from '@/entities/order';
 
@@ -122,6 +123,7 @@ export function ReviewModal({
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const { photo, photoFile, removePhoto, capturePhoto, handleFileSelected, fileInputRef, error: cameraError } = useCameraCapture();
+  const { updateTickets } = useAuth();
 
   // 별점·후기가 바뀔 때마다 초안을 갱신해 둔다. 카메라를 켜는 순간 화면이
   // 정리되더라도 마지막 상태가 남아 있어야 한다.
@@ -154,7 +156,9 @@ export function ReviewModal({
     setSubmitError(null);
 
     try {
-      await createReview(orderId, rating, content, photoFile);
+      const created = await createReview(orderId, rating, content, photoFile);
+      // 반환이 반영된 뒤의 잔여 티켓이다.
+      updateTickets(created.tickets);
 
       // 통과했을 때만 입력을 비운다. 실패하면 별점과 후기를 그대로 두어
       // 사진만 다시 찍어 재시도할 수 있게 한다.

--- a/frontend/src/pages/customer/OrderPage/OrderPage.tsx
+++ b/frontend/src/pages/customer/OrderPage/OrderPage.tsx
@@ -10,9 +10,11 @@ import { getStoreDetail, type StoreDetail } from "@/api/storeApi";
 import { saveOrder } from "@/entities/order/orderStorage";
 import { clearStoreCache } from "@/entities/store";
 import { ApiError } from "@/shared/api";
+import { useAuth } from "@/app/providers";
 
 export function OrderPage() {
   const { storeId } = useParams();
+  const { updateTickets } = useAuth();
   const navigate = useNavigate();
 
   const [storeDetail, setStoreDetail] = useState<StoreDetail | null>(null);
@@ -73,6 +75,8 @@ export function OrderPage() {
       );
       // 서버가 준 주문을 그대로 사본에 남긴다. 서버에 닿지 못할 때 쓴다.
       saveOrder(order);
+      // 서버가 잠금 반영 후의 잔여 티켓을 함께 준다. - 추가 조회 없이 상단 뱃지를 맞춘다.
+      updateTickets(order.tickets);
       setSelectedMenu(null);
       // replace 로 이동해 뒤로가기가 주문 화면으로 돌아오지 않게 한다.
       navigate("/order-history", { replace: true });


### PR DESCRIPTION
customer 도메인 버그 2건 수정입니다.

### 홈 목록 리뷰 뱃지 (#107)
- StoreCard 가 hasReviewEvent 를 안 받아 모든 가게에 "리뷰" 뱃지가 붙었습니다
- 가게상세(DetailStoreCard)와 노출 기준을 맞췄습니다

### 헤더 티켓 개수 (#108)
- 주문·리뷰 작성 후에도 상단 티켓 숫자가 새로고침 전까지 그대로였습니다
- AuthProvider 에 updateTickets 를 추가하고, 주문·리뷰 응답에 이미 실려 오는 잔여 티켓 값으로 갱신합니다. 추가 API 호출은 없습니다
- 같은 컨텍스트를 쓰는 마이페이지 티켓 개수도 함께 맞춰집니다

### 확인
- tsc --noEmit, oxlint 통과 (새 경고 없음)
- 주문 시 헤더 숫자 즉시 감소, 리뷰 작성 성공 시 증가 확인

Closes #107
Closes #108
