### PR TITLE
[owner] 사이드바 로고 수정 / 메뉴 모달 이탈 확인 / 만료 재조회 중복 방지

### DIFF
--- a/frontend/src/api/storeApi.ts
+++ b/frontend/src/api/storeApi.ts
@@ -1,16 +1,6 @@
 import { request } from "@/shared/api";
 import type { Store } from "@/entities/store";
 
-// 강성원 코드
-// export interface StoreSummary {
-//   id: number;
-//   name: string;
-//   imageUrl: string | null;
-//   rating: number;
-//   reviewCount: number;
-//   hasReviewEvent: boolean;
-// }
-
 // 이도연
 export interface MenuItem {
   id: number;
@@ -26,15 +16,6 @@ export interface StoreDetail extends Store {
   menus: MenuItem[];
 }
 
-// 강성원 코드
-// export interface StoreDetail {
-//   id: number;
-//   name: string;
-//   imageUrl: string | null;
-//   rating: number;
-//   reviewCount: number;
-//   menus: MenuItem[];
-// }
 
 // 이도연
 export function getStores(signal?: AbortSignal): Promise<Store[]> {

--- a/frontend/src/pages/owner/MenuManagementPage/MenuEditModal.tsx
+++ b/frontend/src/pages/owner/MenuManagementPage/MenuEditModal.tsx
@@ -46,6 +46,25 @@ export function MenuEditModal({
     ),
   );
   const [error, setError] = useState<string | null>(null);
+  // 오버레이 클릭 시 변경사항이 있으면 바로 닫지 않고 이 확인 다이얼로그를 먼저 띄운다.
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  // 모달이 처음 열렸을 때(props)와 현재 편집 상태를 비교해 변경 여부를 판단한다.
+  // 리뷰이벤트 설정, 대표 사진, 표본 사진 중 하나라도 바뀌면 dirty로 간주한다.
+  const isDirty =
+    hasReviewEvent !== menu.reviewEvent ||
+    imageUrl !== menu.imageUrl ||
+    sampleUrls.some((url, i) => url !== (initialSampleUrls?.[i] ?? null));
+
+  // 오버레이(배경) 클릭 핸들러.
+  // dirty 상태면 확인 다이얼로그를 띄우고, 변경사항이 없으면 바로 닫는다.
+  const handleOverlayClick = () => {
+    if (isDirty) {
+      setShowConfirm(true);
+    } else {
+      onClose();
+    }
+  };
 
   const handleSampleChange = (index: number, url: string) => {
     setError(null);
@@ -63,10 +82,11 @@ export function MenuEditModal({
   };
 
   return (
-    // 모달 오버레이 — 클릭 시 닫힘 
+    <>
+    {/* 모달 오버레이 — 변경 없으면 즉시 닫힘, 있으면 확인 다이얼로그 표시 */}
     <div
       className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-6"
-      onClick={onClose}
+      onClick={handleOverlayClick}
     >
       {/*모달 본문 */}
       <div
@@ -156,5 +176,35 @@ export function MenuEditModal({
         </div>
       </div>
     </div>
+
+    {/* 변경사항이 있을 때 오버레이 클릭 시 나타나는 이탈 확인 다이얼로그.
+        z-[60]으로 기존 모달(z-50) 위에 렌더링된다.
+        다이얼로그 배경 클릭 시 다이얼로그만 닫히고 편집 모달은 유지된다. */}
+    {showConfirm && (
+      <div
+        className="fixed inset-0 z-[60] flex items-center justify-center bg-black/30"
+        onClick={() => setShowConfirm(false)}
+      >
+        <div
+          className="flex flex-col gap-4 rounded-xl bg-white p-6 shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="text-sm font-semibold text-ink-900">
+            수정 중인 내용이 저장되지 않습니다. 나가시겠어요?
+          </p>
+          <div className="flex justify-end gap-2">
+            {/* 계속 수정: 확인 다이얼로그만 닫고 편집 모달로 돌아간다 */}
+            <Button variant="secondary" size="small" onClick={() => setShowConfirm(false)}>
+              계속 수정
+            </Button>
+            {/* 나가기: 변경사항을 버리고 편집 모달을 완전히 닫는다 */}
+            <Button size="small" onClick={onClose}>
+              나가기
+            </Button>
+          </div>
+        </div>
+      </div>
+    )}
+    </>
   );
 }

--- a/frontend/src/pages/owner/ReviewManagementPage/CompletedReviewItem.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/CompletedReviewItem.tsx
@@ -23,7 +23,7 @@ export function CompletedReviewItem({ review }: CompletedReviewItemProps) {
         <span className="text-ink-500">{date}</span>
       </div>
       <p className="text-sm text-ink-700">{review.reviewContent}</p>
-      {/* 리뷰 사진은 AI 검증을 통과해야 저장되므로 항상 한 장 있다 */}
+      {/* 리뷰 사진은 AI 검증을 통과해야 저장되므로 실질적으로 항상 존재하지만, 백엔드 계약 변경에 대비해 체크 유지 */}
       {review.reviewImageUrl && (
         <img
           src={review.reviewImageUrl}

--- a/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
+++ b/frontend/src/pages/owner/ReviewManagementPage/ReviewManagementPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { StatsBar } from './StatsBar';
 import { ReviewTabs, type ReviewTab } from './ReviewTabs';
 import { CompletedReviewItem } from './CompletedReviewItem';
@@ -25,7 +25,14 @@ export function ReviewManagementPage() {
 
   // 카드에 넘기는 값이라 참조가 고정돼야 한다. 인라인 화살표로 넘기면 매 렌더마다
   // 새 함수가 돼 카드의 카운트다운 interval 이 계속 버려지고 다시 만들어진다.
-  const reload = useCallback(() => setReloadKey((k) => k + 1), []);
+  //
+  // 여러 카드가 비슷한 시점에 동시 만료되면 onExpire 가 카드 수만큼 연달아 호출된다.
+  // debounce 로 묶어서 1초 안에 몰린 호출은 재조회 1번으로 합친다.
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reload = useCallback(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => setReloadKey((k) => k + 1), 1000);
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/frontend/src/shared/layout/OwnerLayout/StoreLogoContext.tsx
+++ b/frontend/src/shared/layout/OwnerLayout/StoreLogoContext.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, type ReactNode } from 'react';
-
+import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
+import { getMyStore } from '@/api/storeApi';
 interface StoreLogoContextType {
   logo: string | null;
   setLogo: (logo: string) => void;
@@ -10,6 +10,15 @@ const StoreLogoContext = createContext<StoreLogoContextType | null>(null);
 // 가게 로고를 Sidebar/StoreManagementPage가 같이 보게 하는 Owner 스코프 전용 상태
 export function StoreLogoProvider({ children }: { children: ReactNode }) {
   const [logo, setLogo] = useState<string | null>(null);
+// StoreLogoProvider는 OwnerLayout에서만 쓰이므로, 여기서 setLogo를 내려주면 Sidebar와 StoreManagementPage가 공유 가능
+  useEffect(() => {          
+    const controller = new AbortController();
+    getMyStore(controller.signal)
+      .then((store) => { if (store.logoUrl) setLogo(store.logoUrl); })
+      .catch(() => {});
+    return () => controller.abort();
+  }, []);
+
   return (
     <StoreLogoContext.Provider value={{ logo, setLogo }}>
       {children}


### PR DESCRIPTION
## 변경 내용

- **사이드바 로고 미표시 수정** — `StoreLogoProvider`에서 직접 `getMyStore()`를 호출하도록 변경. 기존엔 가게관리 페이지를 거쳐야만 로고가 채워졌음
- **메뉴 수정 모달 이탈 확인 다이얼로그** — 표본 사진·설정을 바꾼 상태에서 오버레이 바깥 클릭 시 확인 없이 닫히던 문제 수정. 변경사항 있을 때만 다이얼로그 표시
- **만료 카드 재조회 중복 호출 방지** — 손님 리뷰 시간이 만료될 때 카드 여러 장이 동시에 `reload()`를 호출하는 문제를 debounce(1000ms)로 처리. 동시 만료 시 API 재조회 1회만 실행
- `storeApi` 주석 처리된 옛 인터페이스 제거, `CompletedReviewItem` 주석 정리

## 테스트

- [ ] 메뉴관리/리뷰관리 URL에서 F5 → 사이드바 로고 표시 확인
- [ ] 메뉴 수정 모달에서 표본 사진 변경 후 바깥 클릭 → 확인 다이얼로그 표시 확인
- [ ] 리뷰관리에서 카드 여러 개 동시 만료 → 재조회 1회만 발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)