### PR TITLE
[feat] 가게상세 뒤로가기 버튼, 메뉴 선택 상태 표시

### DIFF
--- a/frontend/src/pages/customer/OrderPage/MenuItem.tsx
+++ b/frontend/src/pages/customer/OrderPage/MenuItem.tsx
@@ -10,14 +10,18 @@ export interface MenuItemData {
 export interface MenuItemProps {
   menu: MenuItemData;
   onClick: (menu: MenuItemData) => void;
+  isSelected: boolean;
 }
 
-export function MenuItem({ menu, onClick }: MenuItemProps) {
+export function MenuItem({ menu, onClick, isSelected }: MenuItemProps) {
   return (
     <button
       type="button"
       onClick={() => onClick(menu)}
-      className="w-full flex gap-4 p-4 hover:bg-gray-50 active:bg-gray-100 transition-colors text-left"
+      className={`w-full flex gap-4 p-4 border-2 first:rounded-t-2xl last:rounded-b-2xl transition-colors text-left ${
+        isSelected ? "border-brand-800 bg-brand-50" : "border-transparent hover:bg-gray-50 active:bg-gray-100"
+      }`}
+      aria-pressed={isSelected}
     >
       {/* Image Section */}
       <div className="flex-shrink-0">

--- a/frontend/src/pages/customer/OrderPage/MenuListCard.tsx
+++ b/frontend/src/pages/customer/OrderPage/MenuListCard.tsx
@@ -6,9 +6,11 @@ export type { MenuItemData };
 export interface MenuListCardProps {
   menus: MenuItemData[];
   onMenuClick: (menu: MenuItemData) => void;
+  /** 선택된 메뉴. 없으면 null */
+  selectedMenuId: number | null;
 }
 
-export function MenuListCard({ menus, onMenuClick }: MenuListCardProps) {
+export function MenuListCard({ menus, onMenuClick, selectedMenuId }: MenuListCardProps) {
   return (
     <Card className="p-0 overflow-hidden">
       <div className="divide-y divide-gray-200">
@@ -17,6 +19,7 @@ export function MenuListCard({ menus, onMenuClick }: MenuListCardProps) {
             key={menu.id}
             menu={menu}
             onClick={onMenuClick}
+            isSelected={menu.id === selectedMenuId}
           />
         ))}
       </div>

--- a/frontend/src/pages/customer/OrderPage/OrderPage.tsx
+++ b/frontend/src/pages/customer/OrderPage/OrderPage.tsx
@@ -11,6 +11,7 @@ import { saveOrder } from "@/entities/order/orderStorage";
 import { clearStoreCache } from "@/entities/store";
 import { ApiError } from "@/shared/api";
 import { useAuth } from "@/app/providers";
+import { ChevronLeft } from "lucide-react";
 
 export function OrderPage() {
   const { storeId } = useParams();
@@ -112,6 +113,16 @@ export function OrderPage() {
 
   return (
     <div className="space-y-6 pb-32 px-5">
+      {/* Back Button Section */}
+      <button
+        type="button"
+        onClick={() => navigate("/")}
+        aria-label="가게 목록으로 돌아가기"
+        className="-ml-3 flex size-11 items-center justify-center rounded-lg text-ink-900 hover:bg-fill-100 active:bg-line-100"
+      >
+        <ChevronLeft size={24} />
+      </button>
+
       {/* Store Promotion Card Section */}
       <DetailStoreCard
         storeName={storeDetail.name}
@@ -130,6 +141,7 @@ export function OrderPage() {
           imageUrl: menu.imageUrl,
         }))}
         onMenuClick={handleMenuClick}
+        selectedMenuId={selectedMenu?.id ?? null}
       />
 
       {/* Review Section — 그 가게에 달린 리뷰 전부 */}


### PR DESCRIPTION
customer 가게상세(주문) 화면 기능 2건입니다.

### 뒤로가기 버튼 (#99)
- 본문 최상단에 추가했습니다. 헤더에는 로고와 아이콘 액션만 두는 규칙이라 본문에 뒀습니다
- 항상 홈으로 보냅니다. history back 은 URL 직접 진입·새로고침 뒤에 앱 밖으로 나가버려서 제외했습니다
- 아이콘 단독 버튼이라 aria-label, 터치 타깃 44x44 를 맞췄습니다

### 메뉴 선택 상태 표시 (#113)
- 지금까지는 하단 주문 버튼 가격으로만 어떤 메뉴를 골랐는지 알 수 있었습니다
- 선택된 항목에 brand-800 테두리 + brand-50 배경을 줍니다. 메뉴 수정 모달의 선택 표현과 같은 방식입니다
- 선택 안 된 항목도 border-transparent 를 유지해 선택 시 내용이 밀리지 않습니다
- 목록 첫·마지막 항목은 카드와 같은 라운드를 줘 테두리가 카드 모서리에 잘리지 않게 했습니다

### 확인
- tsc -b, oxlint 통과 (새 경고 없음)
- 뒤로가기 이동, 메뉴 선택·해제, 첫·마지막 항목 테두리, 하단 버튼 가격 연동 확인

Closes #99
Closes #113
