### PR TITLE
[fix] 티켓 동시성 락, 업로드 경로 검증, 메뉴 추가 API

### DIFF
--- a/backend/DB/13_optimistic_lock.sql
+++ b/backend/DB/13_optimistic_lock.sql
@@ -1,0 +1,26 @@
+-- users 에 낙관적 락 컬럼을 추가한다.
+--
+-- tickets 는 읽고-검사하고-쓰는 사이가 비어 있었다. 같은 계정으로 이벤트 주문이
+-- 동시에 들어오면 두 요청이 같은 값을 읽고 각자 검사를 통과해, 보유 티켓보다
+-- 많은 주문이 생성된다(증식). 반대로 리뷰 저장의 티켓 반환이 겹치면 나중 쪽이
+-- 앞선 쪽을 덮어써 한 장이 사라진다(유실). 둘 다 에러도 로그도 안 남는다.
+--
+-- 다만 이 컬럼은 주 수단이 아니라 그물이다. 실제로 티켓을 지키는 것은 조회
+-- 시점에 행을 잠그는 UserRepository.findByIdForUpdate(비관적 락)다.
+--
+-- 낙관적 락만으로는 부족했던 이유 — 주문 생성은 customer_order_table 에 INSERT
+-- 하면서 외래키 때문에 users 행에 공유 락을 먼저 건다. 그 뒤 티켓 UPDATE 가
+-- 배타 락으로 올라가려 하면 두 요청이 서로를 기다려 데드락(MySQL 1213)이 났다.
+-- 처음부터 배타 락을 쥐고 들어가면 승격이 없어 데드락도 없다.
+--
+-- 이 컬럼이 남아 있는 이유 — 잠금 없이 tickets 를 고치는 경로가 나중에 생겼을 때
+-- 값이 조용히 덮어써지는 대신 커밋이 실패해 드러나게 하는 안전장치다.
+--
+-- 기존 행은 DEFAULT 0 으로 채워지므로 별도 백필이 필요 없다.
+-- ddl-auto:validate 라 이 스크립트를 먼저 실행해야 서버가 뜬다.
+--
+-- 실행:
+--   Get-Content "C:\dev\ReviewTicketFullstack\backend\DB\13_optimistic_lock.sql" | & "C:\Program Files\MySQL\MySQL Server 8.4\bin\mysql.exe" -u reviewticket -p -P 21096 --default-character-set=utf8mb4 reviewticket
+
+ALTER TABLE users
+  ADD COLUMN `version` BIGINT NOT NULL DEFAULT 0 COMMENT '낙관적 락. Hibernate 가 갱신할 때마다 +1 한다. 애플리케이션이 직접 읽거나 쓰지 않는다';

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/User.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 
 /**
  * 회원. id 는 가입 순서대로 붙는 내부 번호이며 화면에 노출하지 않는다.
@@ -59,6 +60,20 @@ public class User {
      */
     @Column(nullable = false)
     private int tickets;
+
+    /**
+     * 낙관적 락. tickets 를 지키는 주 수단은 아니다 — 그건 조회 시점에 행을
+     * 잠그는 UserRepository.findByIdForUpdate 쪽이고, 이 컬럼은 그물이다.
+     *
+     * 잠금 없이 tickets 를 고치는 경로가 나중에 생기면, 이 컬럼 덕분에 값이
+     * 조용히 덮어써지는 대신 커밋이 실패해 500 으로 드러난다. 티켓이 소리 없이
+     * 늘거나 줄어드는 것보다 시끄럽게 터지는 편이 찾기 쉽다.
+     *
+     * Hibernate 전용이라 getter 를 두지 않는다. 응답에 실을 값이 아니다.
+     */
+    @Version
+    @Column(nullable = false)
+    private Long version;
 
     /** DB 의 DEFAULT / ON UPDATE 가 채운다. */
     @Column(name = "created_at", insertable = false, updatable = false)

--- a/backend/Server/src/main/java/com/reviewticket/server/image/ImageResizer.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/image/ImageResizer.java
@@ -7,9 +7,13 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.Set;
 
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
 
 import org.springframework.stereotype.Component;
 
@@ -86,6 +90,34 @@ public class ImageResizer {
     public int longEdge(byte[] original) {
         BufferedImage source = read(original);
         return Math.max(source.getWidth(), source.getHeight());
+    }
+
+    /**
+     * 이미 저장된 파일의 긴 변을 구한다. 픽셀을 다 풀지 않고 헤더만 읽는다 —
+     * 표본 사진 검증처럼 크기만 알면 되는 자리에서 쓴다. 메뉴 하나를 저장할 때
+     * 최대 5장을 연속으로 보므로 1920px JPEG 를 통째로 디코딩하는 것과 차이가 난다.
+     *
+     * 이미지가 아니거나 읽을 수 없으면 IllegalArgumentException 을 던진다.
+     */
+    public int longEdge(Path file) {
+        try (ImageInputStream in = ImageIO.createImageInputStream(file.toFile())) {
+            if (in == null) {
+                throw new IllegalArgumentException("이미지를 읽을 수 없습니다: " + file);
+            }
+            Iterator<ImageReader> readers = ImageIO.getImageReaders(in);
+            if (!readers.hasNext()) {
+                throw new IllegalArgumentException("지원하지 않는 이미지 형식입니다: " + file);
+            }
+            ImageReader reader = readers.next();
+            try {
+                reader.setInput(in);
+                return Math.max(reader.getWidth(0), reader.getHeight(0));
+            } finally {
+                reader.dispose();
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지를 읽을 수 없습니다: " + file, e);
+        }
     }
 
     private BufferedImage read(byte[] bytes) {

--- a/backend/Server/src/main/java/com/reviewticket/server/image/ImageStorage.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/image/ImageStorage.java
@@ -36,11 +36,52 @@ public class ImageStorage {
         }
     }
 
+    /**
+     * URL 을 실제 파일 경로로 바꿈다. 업로드 폴더 밖을 가리키는 값은 거절한다.
+     *
+     * 여기서 막지 않으면 "/uploads/../../..." 같은 값으로 서버 안 아무 파일이나
+     * 읽힐 수 있다 — 표본 사진 주소는 사장이 직접 보낸 문자열이지 서버가 만든
+     * 값이 아니다. save() 가 짓는 이름은 항상 UUID + ".jpg" 라 순수 파일명이면 충분하다.
+     *
+     * 문자열 검사와 정규화 후 경로 비교를 둘 다 한다 — 앞쪽을 빠져나가는 표기가
+     * 있더라도 뒤쪽에서 한 번 더 걸리게 한다.
+     */
+    public Path pathOf(String url) {
+        String prefix = properties.upload().baseUrl() + "/";
+        if (url == null || !url.startsWith(prefix)) {
+            throw new IllegalArgumentException("업로드 파일 주소가 아닙니다: " + url);
+        }
+        String filename = url.substring(prefix.length());
+        if (filename.isEmpty() || filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            throw new IllegalArgumentException("파일명이 아닙니다: " + url);
+        }
+
+        Path dir = Path.of(properties.upload().dir()).toAbsolutePath().normalize();
+        Path file = dir.resolve(filename).normalize();
+        if (!file.startsWith(dir)) {
+            throw new IllegalArgumentException("업로드 폴더 밖을 가리킵니다: " + url);
+        }
+        return file;
+    }
+
+    /**
+     * 그 주소의 파일이 실제로 있는지. 표본 사진을 메뉴에 붙이기 전에 확인할 때 쓴다.
+     *
+     * 주소 형식이 이상해도 예외가 아니라 false 다 — 불러지는 쪽은 둘을 구분할 이유가
+     * 없고, 구분해 알려 주면 서버에 어떤 파일이 있는지를 떠볼 수 있게 된다.
+     */
+    public boolean exists(String url) {
+        try {
+            return Files.isRegularFile(pathOf(url));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     /** save() 가 돌려준 URL 로 원본 바이트를 다시 읽는다. AI 비교용 메뉴 표본 사진을 읽을 때 쓴다. */
     public byte[] read(String url) {
         try {
-            String filename = url.substring(properties.upload().baseUrl().length() + 1);
-            return Files.readAllBytes(Path.of(properties.upload().dir()).resolve(filename));
+            return Files.readAllBytes(pathOf(url));
         } catch (IOException e) {
             throw new IllegalStateException("이미지 읽기 실패: " + url, e);
         }

--- a/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/order/OrderService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
@@ -55,7 +56,7 @@ public class OrderService {
 
     @Transactional
     public OrderCreateResponse create(long userId, Long storeId, Long menuId, boolean reviewEventApply) {
-        User customer = requireCustomer(userId);
+        User customer = requireCustomerForUpdate(userId);
 
         Menu menu = menus.findById(menuId)
                 .orElseThrow(() -> new NotFoundException("MENU_NOT_FOUND", "메뉴를 찾을 수 없습니다"));
@@ -131,7 +132,20 @@ public class OrderService {
 
     /** 사장이 주문을 시도하면 막는다. 고객 전용 기능이다. */
     private User requireCustomer(long userId) {
-        User user = users.findById(userId)
+        return checkCustomer(users.findById(userId));
+    }
+
+    /**
+     * 주문 생성 전용. 티켓을 줄이는 트랜잭션이라 행을 배타 락으로 먼저 잡는다 —
+     * 왜 "먼저" 여야 하는지는 UserRepository.findByIdForUpdate 주석에 적었다.
+     * 조회만 하는 findMine 은 락을 걸 이유가 없어 위쪽을 그대로 쓴다.
+     */
+    private User requireCustomerForUpdate(long userId) {
+        return checkCustomer(users.findByIdForUpdate(userId));
+    }
+
+    private static User checkCustomer(Optional<User> found) {
+        User user = found
                 .orElseThrow(() -> new UnauthorizedException("UNAUTHORIZED", "로그인이 필요합니다"));
         if (user.getRole() != Role.CUSTOMER) {
             throw new ForbiddenException("NOT_CUSTOMER", "사장 계정으로 주문을 시도했습니다");

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/MenuRepository.java
@@ -12,4 +12,7 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
 
     /** 그 메뉴 중 하나라도 리뷰이벤트 대상이 있는지. 가게 생성 시 store.markReviewing 을 정하는 데 한 번 쓴다. */
     boolean existsByStoreIdAndReviewEventTrue(Long storeId);
+
+    /** 같은 가게 안에 같은 이름의 메뉴가 이미 있는지. 메뉴 추가 전 중복 검사에 쓴다. */
+    boolean existsByStoreIdAndName(Long storeId, String name);
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/UserRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/UserRepository.java
@@ -3,8 +3,13 @@ package com.reviewticket.server.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.reviewticket.server.domain.User;
+
+import jakarta.persistence.LockModeType;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -17,4 +22,23 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByDisplayName(String displayName);
+
+    /**
+     * 티켓을 건드리는 트랜잭션 전용 조회. 행에 배타 락을 걸어 같은 사용자의
+     * 요청이 겹쳐도 한 번에 하나씩만 지나가게 한다.
+     *
+     * 평범한 findById 로 읽으면 락이 없어, 두 요청이 같은 tickets 값을 보고
+     * 각자 검사를 통과한 뒤 각자 차감한다 — 보유 티켓보다 많은 이벤트 주문이
+     * 생긴다.
+     *
+     * 락을 "맨 앞에서" 잡는 것이 중요하다. 주문 생성은 customer_order_table 에
+     * INSERT 하면서 외래키 때문에 users 행에 공유 락을 먼저 건다. 그 뒤에 티켓을
+     * UPDATE 하려면 배타 락으로 올려야 하는데, 두 요청이 동시에 올리려 하면
+     * 서로가 쥔 공유 락을 기다려 데드락(MySQL 1213)이 난다. 처음부터 배타 락을
+     * 쥐고 들어가면 승격 자체가 없어 두 번째 요청은 그냥 앞이 끝날 때까지
+     * 기다렸다가 갱신된 값을 읽는다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.id = :id")
+    Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/review/ReviewTransaction.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/review/ReviewTransaction.java
@@ -12,13 +12,16 @@ import org.springframework.transaction.annotation.Transactional;
 import com.reviewticket.server.auth.ConflictException;
 import com.reviewticket.server.auth.ForbiddenException;
 import com.reviewticket.server.auth.NotFoundException;
+import com.reviewticket.server.auth.UnauthorizedException;
 import com.reviewticket.server.auth.ValidationException;
 import com.reviewticket.server.domain.Menu;
 import com.reviewticket.server.domain.Order;
 import com.reviewticket.server.domain.Review;
+import com.reviewticket.server.domain.User;
 import com.reviewticket.server.image.ImageStorage;
 import com.reviewticket.server.repository.OrderRepository;
 import com.reviewticket.server.repository.ReviewRepository;
+import com.reviewticket.server.repository.UserRepository;
 
 /**
  * 리뷰 등록의 DB 트랜잭션 경계.
@@ -39,11 +42,14 @@ public class ReviewTransaction {
 
     private final ReviewRepository reviews;
     private final OrderRepository orders;
+    private final UserRepository users;
     private final ImageStorage storage;
 
-    public ReviewTransaction(ReviewRepository reviews, OrderRepository orders, ImageStorage storage) {
+    public ReviewTransaction(ReviewRepository reviews, OrderRepository orders, UserRepository users,
+            ImageStorage storage) {
         this.reviews = reviews;
         this.orders = orders;
+        this.users = users;
         this.storage = storage;
     }
 
@@ -76,13 +82,20 @@ public class ReviewTransaction {
     @Transactional
     public ReviewCreateResponse commit(long userId, Long orderId, int rating, String content,
             byte[] reviewImage, double similarity, String compareImageUrl) {
+        // 티켓을 되돌리는 트랜잭션이라 users 행을 맨 앞에서 배타 락으로 잡는다.
+        // 아래 reviews.save() 가 외래키 때문에 같은 행에 공유 락을 먼저 걸어,
+        // 그 상태에서 티켓을 UPDATE 하면 락 승격 데드락이 난다 — 주문 생성과
+        // 똑같은 구조다(UserRepository.findByIdForUpdate 주석 참고).
+        User customer = users.findByIdForUpdate(userId)
+                .orElseThrow(() -> new UnauthorizedException("UNAUTHORIZED", "로그인이 필요합니다"));
+
         Order order = requireWritableOrder(userId, orderId);
 
         String reviewImageUrl = storage.save(reviewImage);
         Review saved = reviews.save(
                 new Review(order, rating, content, reviewImageUrl, similarity, compareImageUrl));
 
-        order.getCustomer().refundTicket();
+        customer.refundTicket();
         order.getStore().recordReview(rating);
 
         return new ReviewCreateResponse(saved.getId(), order.getId(), saved.getStore().getId(),

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -3,13 +3,16 @@ package com.reviewticket.server.store;
 import java.time.Instant;
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.reviewticket.server.domain.User;
@@ -38,6 +41,20 @@ public class StoreController {
 
     /** 4.4 응답. 4.3(GET, 사장 본인 조회)보다 작다 — 방금 바뀐 값과 갱신 시각만 돌려주면 충분하다. */
     public record UpdateStoreResponse(Long storeId, String storeName, String logoUrl, Instant latestUpdate) {
+    }
+
+    /**
+     * 메뉴 추가 요청.
+     *
+     * 수정(UpdateMenuRequest)과 달리 이름·가격을 받는다 — 그 둘은 생성 때만 정한다.
+     * sampleImageUrls 규칙은 수정과 같다(최대 5장, 최소 1장). 검증은 StoreService 가 한다.
+     */
+    public record CreateMenuRequest(
+            @NotBlank(message = "메뉴 이름을 입력해 주세요") String menuName,
+            int menuPrice,
+            String imageUrl,
+            @NotNull List<String> sampleImageUrls,
+            boolean reviewEvent) {
     }
 
     /**
@@ -84,6 +101,18 @@ public class StoreController {
     @GetMapping("/me/menus")
     public List<MenuOwnerResponse> myMenus(@AuthenticationPrincipal User user) {
         return storeService.findMyMenus(user.getId());
+    }
+
+    /**
+     * 새 메뉴를 추가한다. 응답은 GET /me/menus 한 줄과 같은 모양이라
+     * 화면이 목록에 그대로 덧붙이면 된다.
+     */
+    @PostMapping(value = "/me/menus", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public MenuOwnerResponse createMyMenu(@AuthenticationPrincipal User user,
+            @Valid @RequestBody CreateMenuRequest request) {
+        return storeService.createMyMenu(user.getId(), request.menuName(), request.menuPrice(),
+                request.imageUrl(), request.sampleImageUrls(), request.reviewEvent());
     }
 
     /** 대표 사진·표본 사진(최대 5장)·리뷰이벤트 여부를 고친다. 메뉴 이름·가격은 여전히 고정이다. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -14,14 +14,19 @@ import com.reviewticket.server.auth.ForbiddenException;
 import com.reviewticket.server.auth.NotFoundException;
 import com.reviewticket.server.auth.UnauthorizedException;
 import com.reviewticket.server.auth.ValidationException;
+import com.reviewticket.server.config.ReviewTicketProperties;
 import com.reviewticket.server.domain.Menu;
 import com.reviewticket.server.domain.Role;
 import com.reviewticket.server.domain.Store;
 import com.reviewticket.server.domain.User;
+import com.reviewticket.server.image.ImageResizer;
+import com.reviewticket.server.image.ImageStorage;
 import com.reviewticket.server.repository.MenuRepository;
 import com.reviewticket.server.repository.PendingSignupRepository;
 import com.reviewticket.server.repository.StoreRepository;
 import com.reviewticket.server.repository.UserRepository;
+
+import jakarta.persistence.EntityManager;
 
 /**
  * 가게, 메뉴 조회와 생성.
@@ -33,36 +38,32 @@ public class StoreService {
     private final MenuRepository menus;
     private final UserRepository users;
     private final PendingSignupRepository pendings;
+    private final EntityManager entityManager;
+    private final ImageStorage storage;
+    private final ImageResizer resizer;
+    private final ReviewTicketProperties properties;
 
     public StoreService(StoreRepository stores, MenuRepository menus,
-            UserRepository users, PendingSignupRepository pendings) {
+            UserRepository users, PendingSignupRepository pendings, EntityManager entityManager,
+            ImageStorage storage, ImageResizer resizer, ReviewTicketProperties properties) {
         this.stores = stores;
         this.menus = menus;
         this.users = users;
         this.pendings = pendings;
-    }
-
-    /**
-     * 프로토타입용 기본 메뉴. 프론트(OrderPage, MenuManagementPage)가 이미 이
-     * 5종을 화면에 고정해 두고 있어 이름과 리뷰이벤트 여부를 거기 맞춘다.
-     *
-     * 메뉴관리 API가 붙으면 이 상수와 아래 생성 코드를 지운다.
-     */
-    private record SeedMenu(String name, int price, boolean reviewEvent) {
+        this.entityManager = entityManager;
+        this.storage = storage;
+        this.resizer = resizer;
+        this.properties = properties;
     }
 
     /** 메뉴 하나가 가질 수 있는 표본 사진 수. 프론트 SAMPLE_IMAGE_COUNT 와 같은 값이다. */
     private static final int MAX_SAMPLE_IMAGES = 5;
 
-    private static final List<SeedMenu> SEED_MENUS = List.of(
-            new SeedMenu("피자", 18000, true),
-            new SeedMenu("햄버거", 9000, true),
-            new SeedMenu("치킨윙", 15000, false),
-            new SeedMenu("비빔밥", 10000, false),
-            new SeedMenu("라멘", 11000, false));
+    /** 메뉴 이름 길이 상한. menu_table.menu_name 이 VARCHAR(32) 라 거기 맞춘다. */
+    private static final int MAX_MENU_NAME_LENGTH = 32;
 
     /**
-     * 사장 회원가입이 확정될 때 가게와 기본 메뉴를 함께 만든다.
+     * 사장 회원가입이 확정될 때 가게를 만든다.
      *
      * 이미 가게가 있으면 아무것도 하지 않는다 — 가입 확정은 한 번뿐이지만,
      * 이 메서드가 다른 경로에서 다시 불려도 가게가 둘로 늘지 않아야 한다.
@@ -72,15 +73,7 @@ public class StoreService {
         if (stores.existsByOwner(owner)) {
             return;
         }
-        Store store = stores.save(new Store(owner, owner.getDisplayName()));
-        menus.saveAll(SEED_MENUS.stream()
-                .map(seed -> new Menu(store, seed.name(), seed.price(), null, seed.reviewEvent()))
-                .toList());
-
-        // review_event 대상 메뉴가 하나라도 있는지 여기서 한 번만 계산해 둔다.
-        // 메뉴 수정 API가 없어 이후로는 바뀔 일이 없다.
-        boolean reviewing = menus.existsByStoreIdAndReviewEventTrue(store.getId());
-        store.markReviewing(reviewing);
+        stores.save(new Store(owner, owner.getDisplayName()));
     }
 
     /** 홈 목록. 최신 가게가 먼저 온다. */
@@ -154,6 +147,56 @@ public class StoreService {
     }
 
     /**
+     * POST /api/stores/me/menus. 새 메뉴를 한 줄 만든다.
+     *
+     * 수정(updateMyMenu)과 달리 이름·가격을 받는다 — 그 둘은 생성 때만 정하고
+     * 그 뒤로는 고치지 않는다.
+     *
+     * 표본 사진을 최소 한 장 요구하는 것도 updateMyMenu 와 같다 — 표본이 없으면
+     * AI 대조 기준이 없어 그 메뉴로는 리뷰를 받을 수 없는 메뉴가 된다.
+     */
+    @Transactional
+    public MenuOwnerResponse createMyMenu(long userId, String rawName, int price, String imageUrl,
+            List<String> sampleImageUrls, boolean reviewEvent) {
+        Store store = storeOf(requireOwner(userId));
+
+        String name = rawName == null ? "" : rawName.trim();
+        if (name.isEmpty()) {
+            throw new ValidationException("MENU_NAME_REQUIRED", "메뉴 이름을 입력해 주세요");
+        }
+        if (name.length() > MAX_MENU_NAME_LENGTH) {
+            throw new ValidationException("MENU_NAME_TOO_LONG",
+                    "메뉴 이름은 " + MAX_MENU_NAME_LENGTH + "자 이하여야 합니다");
+        }
+        if (price < 0) {
+            throw new ValidationException("MENU_PRICE_INVALID", "가격은 0원 이상이어야 합니다");
+        }
+        // 같은 가게 안에서만 막는다. 다른 가게에 같은 이름의 메뉴가 있는 건 정상이다.
+        if (menus.existsByStoreIdAndName(store.getId(), name)) {
+            throw new ConflictException("MENU_NAME_TAKEN", "이미 쓰이고 있는 메뉴 이름입니다");
+        }
+
+        List<String> samples = sampleImageUrls == null ? List.of() : sampleImageUrls;
+        requireValidSamples(samples);
+
+        // 생성자는 표본 5칸을 모른다. 칸을 채우는 규칙을 두 군데 두지 않도록
+        // 저장 전에 applyEdit 을 한 번 통과시킨다 — updateMyMenu 와 같은 코드를 타게 된다.
+        Menu menu = new Menu(store, name, price, imageUrl, reviewEvent);
+        menu.applyEdit(imageUrl, samples, reviewEvent);
+        Menu saved = menus.saveAndFlush(menu);
+
+        // 생성 시각·갱신 시각은 DB 기본값(CURRENT_TIMESTAMP)으로 채워진다.
+        // INSERT 후 다시 읽어와야 응답에 그 두 값을 실어 보낼 수 있다.
+        entityManager.refresh(saved);
+
+        if (reviewEvent) {
+            store.markReviewing(true);
+        }
+
+        return toMenuOwnerResponse(saved);
+    }
+
+    /**
      * PATCH /api/stores/me/menus/{menuId}. 대표 사진·표본 사진·리뷰이벤트 여부를
      * 통째로 덮어쓴다.
      *
@@ -175,6 +218,25 @@ public class StoreService {
         }
 
         List<String> samples = sampleImageUrls == null ? List.of() : sampleImageUrls;
+        requireValidSamples(samples);
+
+        menu.applyEdit(imageUrl, samples, reviewEvent);
+        store.markReviewing(menus.existsByStoreIdAndReviewEventTrue(store.getId()));
+
+        return toMenuOwnerResponse(menu);
+    }
+
+    /**
+     * 표본 사진 규칙. 메뉴 추가와 메뉴 수정이 같은 기준을 써야 해서 한 군데 모아 둔다.
+     *
+     * 빈 칸(null)은 허용하되 전부 비어 있으면 거절한다 — 한 장도 없으면 AI 대조를 못 한다.
+     *
+     * 갯수만 보는 게 아니라 그 주소가 가리키는 파일까지 열어본다. 업로드 때 크기를
+     * 검사하지만(UploadController 의 minLongEdge) 그건 부르는 쪽이 선택하는 값이라,
+     * 검사 없이 받은 주소를 그대로 표본 칸에 넣으면 아무도 다시 보지 않았다.
+     * 붙이는 시점인 여기서 보면 주소를 어떻게 얻어 왔든 상관없어진다.
+     */
+    private void requireValidSamples(List<String> samples) {
         if (samples.size() > MAX_SAMPLE_IMAGES) {
             throw new ValidationException("TOO_MANY_SAMPLE_IMAGES",
                     "표본 사진은 " + MAX_SAMPLE_IMAGES + "장까지만 등록할 수 있습니다");
@@ -183,10 +245,32 @@ public class StoreService {
             throw new ValidationException("SAMPLE_IMAGE_REQUIRED", "표본 사진을 한 장 이상 등록해야 합니다");
         }
 
-        menu.applyEdit(imageUrl, samples, reviewEvent);
-        store.markReviewing(menus.existsByStoreIdAndReviewEventTrue(store.getId()));
+        // 리뷰 사진에 요구하는 하한과 같은 값을 쓴다 — 대조하는 두 사진 중 기준 쪽만
+        // 저화질이면 같은 음식을 찍은 리뷰도 유사도가 낮게 나와 거부된다.
+        int minLongEdge = properties.review().minImageLongEdge();
 
-        return toMenuOwnerResponse(menu);
+        for (String url : samples) {
+            if (url == null) {
+                continue;
+            }
+            // 파일이 없는 경우와 이미지로 못 읽는 경우를 하나로 묶는다 — 화면 입장에선
+            // 둘 다 "이 사진은 못 쓴다"로 같고, 구분해 알려 주면 서버에 어떤 파일이
+            // 있는지를 떠볼 수 있게 된다.
+            if (!storage.exists(url)) {
+                throw new ValidationException("SAMPLE_IMAGE_NOT_FOUND", "표본 사진을 찾을 수 없습니다");
+            }
+
+            int longEdge;
+            try {
+                longEdge = resizer.longEdge(storage.pathOf(url));
+            } catch (IllegalArgumentException e) {
+                throw new ValidationException("SAMPLE_IMAGE_NOT_FOUND", "표본 사진을 이미지로 읽을 수 없습니다");
+            }
+            if (longEdge < minLongEdge) {
+                throw new ValidationException("SAMPLE_IMAGE_TOO_SMALL",
+                        "표본 사진은 긴 변이 " + minLongEdge + "px 이상이어야 합니다");
+            }
+        }
     }
 
     /** 사장 전용 기능을 지키는 공통 관문. 고객 계정이면 403, 못 찾으면 401. */


### PR DESCRIPTION
dev 에 아직 반영되지 않은 백엔드 수정 3건을 합친다.

## 포함 커밋

- `[fix] 티켓 동시 차감·반환에 비관적 락 적용` - 동시 요청에서 티켓 수량이 어긋나던 문제를 막는다.
- `[fix] 업로드 파일 주소에 경로 검증 추가` - 업로드 경로를 벗어나는 주소를 걸러낸다.
- `[feat] 메뉴 추가 API 신설, 기본 메뉴 5종 제거`

## 합치는 이유

메뉴 추가 API 를 갖다 쓰는 프론트 작업(#121)이 이미 dev 에 들어가 있는데,
정작 그 API 를 만드는 백엔드 커밋이 이 브랜치에 남아 있어 dev 만 보면
프론트가 없는 API 를 호출하는 상태였다.

## 확인한 것

- dev 와의 충돌 없음 (`git merge-tree` 시험 병합 결과 충돌 파일 0건)
- 변경 범위는 backend 하위 자바 파일 9개와 `backend/DB/13_optimistic_lock.sql` 1개
