### PR TITLE
[feat] GET /api/stores 에 page, size 쿼리 파라미터 추가 (기본 0, 20)

### DIFF
--- a/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
@@ -12,7 +12,7 @@ import com.reviewticket.server.domain.User;
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     /** 홈 목록. 최신 가게가 먼저 온다. */
-    Page<Store> findAllByOrderByIdDesc(Pageable Pageable);
+    Page<Store> findAllByOrderByIdDesc(Pageable pageable);
 
     boolean existsByOwner(User owner);
 

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
@@ -1,9 +1,10 @@
 package com.reviewticket.server.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import com.reviewticket.server.domain.Store;
 import com.reviewticket.server.domain.User;
@@ -11,7 +12,7 @@ import com.reviewticket.server.domain.User;
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
     /** 홈 목록. 최신 가게가 먼저 온다. */
-    List<Store> findAllByOrderByIdDesc();
+    Page<Store> findAllByOrderByIdDesc(Pageable Pageable);
 
     boolean existsByOwner(User owner);
 

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -17,6 +17,7 @@ import com.reviewticket.server.domain.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * 가게, 메뉴 조회와 사장의 가게 관리.
@@ -54,10 +55,12 @@ public class StoreController {
             boolean reviewEvent, Instant menuLatestUpdate) {
     }
 
-    /** 홈 목록. 개수 제한과 페이지네이션은 두지 않았다. */
+    /** 홈 목록. 페이지네이션 지원 (20개씩 응답). */
     @GetMapping
-    public List<StoreSummaryResponse> stores() {
-        return storeService.findAll();
+    public List<StoreSummaryResponse> stores(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return storeService.findAll(page, size);
     }
 
     /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.reviewticket.server.domain.User;
@@ -56,8 +57,12 @@ public class StoreController {
 
     /** 홈 목록. 개수 제한과 페이지네이션은 두지 않았다. */
     @GetMapping
-    public List<StoreSummaryResponse> stores() {
-        return storeService.findAll();
+    public List<StoreSummaryResponse> stores(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size) {
+         {
+            return storeService.findAll(page, size);
+        }
     }
 
     /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -18,7 +18,6 @@ import com.reviewticket.server.domain.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * 가게, 메뉴 조회와 사장의 가게 관리.
@@ -61,9 +60,7 @@ public class StoreController {
     public List<StoreSummaryResponse> stores(
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size) {
-         {
             return storeService.findAll(page, size);
-        }
     }
 
     /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -82,8 +82,6 @@ public class StoreService {
     /** 홈 목록. 최신 가게가 먼저 온다. 페이지네이션 지원 (20개씩 응답). */
     @Transactional(readOnly = true)
     public List<StoreSummaryResponse> findAll(int page, int size) {
-        System.out.println("PAGE = " + page);
-    System.out.println("SIZE = " + size);
 
         Pageable pageable = PageRequest.of(
             page,

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -86,7 +86,7 @@ public class StoreService {
 
     /** 홈 목록. 최신 가게가 먼저 온다. 페이지네이션 지원 (20개씩 응답). */
     @Transactional(readOnly = true)
-    public List<StoreSummaryResponse> findAll(int page, int size, Sort.by(Sort.Direction.ASC, "storeId")) {
+    public List<StoreSummaryResponse> findAll(int page, int size) {
         int offset = page * size;
         return stores.findAllByOrderByIdDesc().stream()
                 .skip(offset)

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -6,8 +6,11 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Pageable;
 
 import com.reviewticket.server.auth.ConflictException;
 import com.reviewticket.server.auth.ForbiddenException;
@@ -85,10 +88,16 @@ public class StoreService {
 
     /** 홈 목록. 최신 가게가 먼저 온다. */
     @Transactional(readOnly = true)
-    public List<StoreSummaryResponse> findAll() {
-        return stores.findAllByOrderByIdDesc().stream()
+    public List<StoreSummaryResponse> findAll(int page, int size) {
+        Pageable pageable = PageRequest.of(
+            page,
+            size,
+            Sort.by(Sort.Direction.DESC, "id")
+        );
+
+        return stores.findAllByOrderByIdDesc(pageable)
                 .map(StoreService::toSummary)
-                .toList();
+                .getContent();
     }
 
     /** 주문 화면용 상세. 가게 정보에 그 가게 메뉴를 붙여 돌려준다. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
-import java.util.Arrays;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageRequest;
@@ -90,6 +89,9 @@ public class StoreService {
     /** 홈 목록. 최신 가게가 먼저 온다. 페이지네이션 지원 (20개씩 응답). */
     @Transactional(readOnly = true)
     public List<StoreSummaryResponse> findAll(int page, int size) {
+        System.out.println("PAGE = " + page);
+    System.out.println("SIZE = " + size);
+
         Pageable pageable = PageRequest.of(
             page,
             size,

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
+import java.util.Arrays;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,10 +84,13 @@ public class StoreService {
         store.markReviewing(reviewing);
     }
 
-    /** 홈 목록. 최신 가게가 먼저 온다. */
+    /** 홈 목록. 최신 가게가 먼저 온다. 페이지네이션 지원 (20개씩 응답). */
     @Transactional(readOnly = true)
-    public List<StoreSummaryResponse> findAll() {
+    public List<StoreSummaryResponse> findAll(int page, int size, Sort.by(Sort.Direction.ASC, "storeId")) {
+        int offset = page * size;
         return stores.findAllByOrderByIdDesc().stream()
+                .skip(offset)
+                .limit(size)
                 .map(StoreService::toSummary)
                 .toList();
     }

--- a/frontend/src/api/storeApi.ts
+++ b/frontend/src/api/storeApi.ts
@@ -18,8 +18,12 @@ export interface StoreDetail extends Store {
 
 
 // 이도연
-export function getStores(signal?: AbortSignal): Promise<Store[]> {
-  return request<Store[]>("/stores", { auth: true, signal });
+export function getStores(page: number = 0, size: number = 20, signal?: AbortSignal): Promise<Store[]> {
+  return request<Store[]>("/stores", {
+    auth: true,
+    signal,
+    query: { page: page.toString(), size: size.toString() }
+  });
 }
 
 // 이도연

--- a/frontend/src/api/storeApi.ts
+++ b/frontend/src/api/storeApi.ts
@@ -16,10 +16,16 @@ export interface StoreDetail extends Store {
   menus: MenuItem[];
 }
 
-
 // 이도연
-export function getStores(signal?: AbortSignal): Promise<Store[]> {
-  return request<Store[]>("/stores", { auth: true, signal });
+export function getStores(
+  page: number,
+  size: number,
+  signal?: AbortSignal,
+): Promise<Store[]> {
+  return request<Store[]>(`/stores?page=${page}&size=${size}`, {
+    auth: true,
+    signal,
+  });
 }
 
 // 이도연
@@ -144,4 +150,3 @@ export function updateMyMenu(
     auth: true,
   });
 }
-

--- a/frontend/src/api/storeApi.ts
+++ b/frontend/src/api/storeApi.ts
@@ -11,12 +11,10 @@ export interface MenuItem {
   reviewEvent: boolean;
 }
 
-// 이도연 코드
 export interface StoreDetail extends Store {
   menus: MenuItem[];
 }
 
-// 이도연
 export function getStores(
   page: number,
   size: number,
@@ -28,7 +26,6 @@ export function getStores(
   });
 }
 
-// 이도연
 export function getStoreDetail(
   storeId: number,
   signal?: AbortSignal,

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -118,19 +118,16 @@ export function HomePage() {
         setIsLoading(true);
         getStores(page, 20)
           .then((data) => {
+            setStores((prev) => {
+              const updated = [...prev, ...data];
+              setCachedStores(updated, page + 1);
+              return updated;
+            });
+
             if (data.length < 20) {
               setHasMore(false);
             } else {
-              setStores((prev) => {
-                const updated = [...prev, ...data];
-                setCachedStores(updated, page + 1);
-                return updated;
-              });
               setPage((prev) => prev + 1);
-
-              if (data.length < 20) {
-                setHasMore(false);
-              }
             }
           })
           .catch(() => {

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -43,12 +43,14 @@ function setCachedStores(stores: Store[]) {
   );
 }
 
-const FOODS = ['치킨윙', '피자', '비빔밥', '라멘', '햄버거'];
+const FOODS = ["치킨윙", "피자", "비빔밥", "라멘", "햄버거"];
 
 export function HomePage() {
   const { user } = useAuth();
   const [stores, setStores] = useState<Store[]>([]);
-  const [selectedFoodIndex, setSelectedFoodIndex] = useState<number | null>(null);
+  const [selectedFoodIndex, setSelectedFoodIndex] = useState<number | null>(
+    null,
+  );
 
   useEffect(() => {
     setSelectedFoodIndex(Math.floor(Math.random() * FOODS.length));
@@ -63,7 +65,7 @@ export function HomePage() {
     // 별점이 함께 들어 있는데, 그 둘은 리뷰가 등록될 때마다 바뀌는 값이다.
     // 캐시에서 멈추면 리뷰를 써도 홈 화면은 자정까지 예전 숫자(리뷰 0)를
     // 보여줘, 등록이 안 된 것처럼 보인다.
-    getStores()
+    getStores(0, 20)
       .then((data) => {
         setStores(data);
         if (data.length > 0) setCachedStores(data);
@@ -86,11 +88,16 @@ export function HomePage() {
               <span>오늘 식사는</span>
               <div className="inline-flex h-6 overflow-hidden">
                 <div
-                  className={selectedFoodIndex !== null ? "animate-food-slot" : ""}
+                  className={
+                    selectedFoodIndex !== null ? "animate-food-slot" : ""
+                  }
                   style={
                     selectedFoodIndex !== null
                       ? (() => {
-                          const finalPos = -(19 * 5 * 24 + selectedFoodIndex * 24);
+                          const finalPos = -(
+                            19 * 5 * 24 +
+                            selectedFoodIndex * 24
+                          );
                           return {
                             "--final-translate-y": `${finalPos}px`,
                             "--pos-60": `${finalPos * 0.92}px`,

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -76,70 +76,69 @@ export function HomePage() {
   useEffect(() => {
     // 캐시가 있으면 먼저 그려 첫 화면이 비어 보이지 않게 한다.
     const cached = getCachedStores();
-    if (cached) setStores(cached);
+    if (cached) {
+      setStores(cached);
+    }
 
     // 캐시가 있어도 서버에 반드시 다시 물어본다. 이 목록에는 리뷰 수와 평균
     // 별점이 함께 들어 있는데, 그 둘은 리뷰가 등록될 때마다 바뀌는 값이다.
     // 캐시에서 멈추면 리뷰를 써도 홈 화면은 자정까지 예전 숫자(리뷰 0)를
     // 보여줘, 등록이 안 된 것처럼 보인다.
-    getStores(0, 20)
+    getStores(page, 20)
       .then((data) => {
+        console.log("첫페이지", data.length);
         setStores(data);
-        if (data.length > 0) setCachedStores(data);
+        setPage(1);
+        setHasMore(data.length === 20);
+        if (data.length > 0) {
+          setCachedStores(data, 1);
+        }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error("첫페이지요청실패", error);
         // 서버에 닿지 못하면 위에서 그린 캐시를 그대로 둔다. 캐시도 없으면 빈 상태다.
       });
   }, []);
 
   useEffect(() => {
-    // 첫 페이지 데이터 로드
-    if (stores.length === 0 && page === 0 && !isLoading) {
-      setIsLoading(true);
-      getStores(0, 20)
-        .then((data) => {
-          if (data.length === 0) {
-            setHasMore(false);
-          } else {
-            setStores(data);
-            setCachedStores(data, 1);
-            setPage(1);
-          }
-        })
-        .catch(() => {
-          // 서버에 닿지 못하면 무시한다.
-        })
-        .finally(() => {
-          setIsLoading(false);
-        });
-    }
-  }, []);
-
-  useEffect(() => {
     const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore && !isLoading && page > 0) {
-          setIsLoading(true);
-          getStores(page, 20)
-            .then((data) => {
-              if (data.length === 0) {
-                setHasMore(false);
-              } else {
-                setStores((prev) => {
-                  const updated = [...prev, ...data];
-                  setCachedStores(updated, page + 1);
-                  return updated;
-                });
-                setPage((prev) => prev + 1);
-              }
-            })
-            .catch(() => {
-              // 서버에 닿지 못하면 무시한다.
-            })
-            .finally(() => {
-              setIsLoading(false);
-            });
+      ([entry]) => {
+        console.log("Observer:", {
+          isIntersecting: entry.isIntersecting,
+          page,
+          hasMore,
+          isLoading,
+        });
+
+        if (!entry.isIntersecting || !hasMore || isLoading || page <= 0) {
+          return;
         }
+        console.log("다음페이지요청", page);
+
+        setIsLoading(true);
+        getStores(page, 20)
+          .then((data) => {
+            if (data.length < 20) {
+              setHasMore(false);
+            } else {
+              setStores((prev) => {
+                const updated = [...prev, ...data];
+                setCachedStores(updated, page + 1);
+                return updated;
+              });
+              setPage((prev) => prev + 1);
+
+              if (data.length < 20) {
+                setHasMore(false);
+              }
+            }
+          })
+          .catch(() => {
+            // 서버에 닿지 못하면 무시한다.
+          })
+          .finally(() => {
+            setIsLoading(false);
+          });
       },
       { threshold: 0.5 },
     );
@@ -148,7 +147,9 @@ export function HomePage() {
       observer.observe(sentinelRef.current);
     }
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+    };
   }, [page, isLoading, hasMore]);
 
   return (

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -29,18 +29,6 @@ function getCachedStores(): Store[] | null {
   return null;
 }
 
-function getCachedPage(): number {
-  const cached = localStorage.getItem(STORE_CACHE_KEY);
-  if (!cached) return 1;
-
-  try {
-    const { page } = JSON.parse(cached);
-    return page || 1;
-  } catch {
-    return 1;
-  }
-}
-
 function setCachedStores(stores: Store[], page: number = 1) {
   const nextMidnight = new Date();
   nextMidnight.setHours(24, 0, 0, 0);
@@ -85,17 +73,8 @@ export function HomePage() {
     // 캐시에서 멈추면 리뷰를 써도 홈 화면은 자정까지 예전 숫자(리뷰 0)를
     // 보여줘, 등록이 안 된 것처럼 보인다.
     getStores(page, 20)
-      .then((data) => {
-        console.log("첫페이지", data.length);
-        setStores(data);
-        setPage(1);
-        setHasMore(data.length === 20);
-        if (data.length > 0) {
-          setCachedStores(data, 1);
-        }
-      })
-      .catch((error) => {
-        console.error("첫페이지요청실패", error);
+      .then(() => {})
+      .catch(() => {
         // 서버에 닿지 못하면 위에서 그린 캐시를 그대로 둔다. 캐시도 없으면 빈 상태다.
       });
   }, []);
@@ -103,17 +82,9 @@ export function HomePage() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        console.log("Observer:", {
-          isIntersecting: entry.isIntersecting,
-          page,
-          hasMore,
-          isLoading,
-        });
-
         if (!entry.isIntersecting || !hasMore || isLoading || page <= 0) {
           return;
         }
-        console.log("다음페이지요청", page);
 
         setIsLoading(true);
         getStores(page, 20)

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Card } from "@/shared/ui";
 import { StoreCard } from "./StoreCard";
 import { useAuth } from "@/app/providers";
@@ -29,7 +29,19 @@ function getCachedStores(): Store[] | null {
   return null;
 }
 
-function setCachedStores(stores: Store[]) {
+function getCachedPage(): number {
+  const cached = localStorage.getItem(STORE_CACHE_KEY);
+  if (!cached) return 1;
+
+  try {
+    const { page } = JSON.parse(cached);
+    return page || 1;
+  } catch {
+    return 1;
+  }
+}
+
+function setCachedStores(stores: Store[], page: number = 1) {
   const nextMidnight = new Date();
   nextMidnight.setHours(24, 0, 0, 0);
 
@@ -37,18 +49,25 @@ function setCachedStores(stores: Store[]) {
     STORE_CACHE_KEY,
     JSON.stringify({
       stores,
+      page,
       timestamp: Date.now(),
       expiresAt: nextMidnight.getTime(),
     }),
   );
 }
 
-const FOODS = ['치킨윙', '피자', '비빔밥', '라멘', '햄버거'];
+const FOODS = ["치킨윙", "피자", "비빔밥", "라멘", "햄버거"];
 
 export function HomePage() {
   const { user } = useAuth();
   const [stores, setStores] = useState<Store[]>([]);
-  const [selectedFoodIndex, setSelectedFoodIndex] = useState<number | null>(null);
+  const [selectedFoodIndex, setSelectedFoodIndex] = useState<number | null>(
+    null,
+  );
+  const [page, setPage] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setSelectedFoodIndex(Math.floor(Math.random() * FOODS.length));
@@ -58,20 +77,66 @@ export function HomePage() {
     // 캐시가 있으면 먼저 그려 첫 화면이 비어 보이지 않게 한다.
     const cached = getCachedStores();
     if (cached) setStores(cached);
-
-    // 캐시가 있어도 서버에 반드시 다시 물어본다. 이 목록에는 리뷰 수와 평균
-    // 별점이 함께 들어 있는데, 그 둘은 리뷰가 등록될 때마다 바뀌는 값이다.
-    // 캐시에서 멈추면 리뷰를 써도 홈 화면은 자정까지 예전 숫자(리뷰 0)를
-    // 보여줘, 등록이 안 된 것처럼 보인다.
-    getStores()
-      .then((data) => {
-        setStores(data);
-        if (data.length > 0) setCachedStores(data);
-      })
-      .catch(() => {
-        // 서버에 닿지 못하면 위에서 그린 캐시를 그대로 둔다. 캐시도 없으면 빈 상태다.
-      });
   }, []);
+
+  useEffect(() => {
+    // 첫 페이지 데이터 로드
+    if (stores.length === 0 && page === 0 && !isLoading) {
+      setIsLoading(true);
+      getStores(0, 20)
+        .then((data) => {
+          if (data.length === 0) {
+            setHasMore(false);
+          } else {
+            setStores(data);
+            setCachedStores(data, 1);
+            setPage(1);
+          }
+        })
+        .catch(() => {
+          // 서버에 닿지 못하면 무시한다.
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, []);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasMore && !isLoading && page > 0) {
+          setIsLoading(true);
+          getStores(page, 20)
+            .then((data) => {
+              if (data.length === 0) {
+                setHasMore(false);
+              } else {
+                setStores((prev) => {
+                  const updated = [...prev, ...data];
+                  setCachedStores(updated, page + 1);
+                  return updated;
+                });
+                setPage((prev) => prev + 1);
+              }
+            })
+            .catch(() => {
+              // 서버에 닿지 못하면 무시한다.
+            })
+            .finally(() => {
+              setIsLoading(false);
+            });
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    if (sentinelRef.current) {
+      observer.observe(sentinelRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, [page, isLoading, hasMore]);
 
   return (
     <div className="space-y-4 px-5 py-6">
@@ -86,11 +151,16 @@ export function HomePage() {
               <span>오늘 식사는</span>
               <div className="inline-flex h-6 overflow-hidden">
                 <div
-                  className={selectedFoodIndex !== null ? "animate-food-slot" : ""}
+                  className={
+                    selectedFoodIndex !== null ? "animate-food-slot" : ""
+                  }
                   style={
                     selectedFoodIndex !== null
                       ? (() => {
-                          const finalPos = -(19 * 5 * 24 + selectedFoodIndex * 24);
+                          const finalPos = -(
+                            19 * 5 * 24 +
+                            selectedFoodIndex * 24
+                          );
                           return {
                             "--final-translate-y": `${finalPos}px`,
                             "--pos-60": `${finalPos * 0.92}px`,
@@ -131,6 +201,14 @@ export function HomePage() {
           />
         ))}
       </div>
+
+      {/* Infinite Scroll Sentinel */}
+      <div ref={sentinelRef} className="h-4" />
+
+      {/* Loading Indicator */}
+      {isLoading && (
+        <div className="py-4 text-center text-sm text-ink-500">로딩 중...</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/customer/OrderPage/DetailStoreCard.tsx
+++ b/frontend/src/pages/customer/OrderPage/DetailStoreCard.tsx
@@ -6,6 +6,7 @@ export interface DetailStoreCardProps {
   rating: number;
   reviewCount: string;
   hasReviewEvent: boolean;
+  onReviewClick?: () => void;
 }
 
 export function DetailStoreCard({
@@ -13,6 +14,7 @@ export function DetailStoreCard({
   rating,
   reviewCount,
   hasReviewEvent,
+  onReviewClick,
 }: DetailStoreCardProps) {
   return (
     <Card className="flex flex-col gap-4 p-5">
@@ -34,10 +36,12 @@ export function DetailStoreCard({
       <div className="flex items-center gap-2">
         <Star size={16} className="fill-yellow-400 text-yellow-400" />
         <span className="text-base font-bold">{rating}</span>
-        <span className="text-sm text-gray-600">
-          리뷰 {reviewCount}
-          {">"}
-        </span>
+        <button
+          onClick={onReviewClick}
+          className="text-sm text-gray-600 font-black cursor-pointer hover:text-gray-900 transition-colors"
+        >
+          리뷰 {reviewCount} {">"}
+        </button>
       </div>
     </Card>
   );

--- a/frontend/src/pages/customer/ReviewsPage/ReviewsPage.tsx
+++ b/frontend/src/pages/customer/ReviewsPage/ReviewsPage.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { Card } from "@/shared/ui";
+import { getMyOrders } from "@/api/orderApi";
+import { getStoreReviews, type PublicReview } from "@/api/reviewApi";
+import { formatOrderDate } from "@/entities/order/reviewTime";
+
+interface ReviewWithStore extends PublicReview {
+  storeName: string;
+}
+
+export function ReviewsPage() {
+  const [reviews, setReviews] = useState<ReviewWithStore[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const fetchReviews = async () => {
+      try {
+        const orders = await getMyOrders(controller.signal);
+
+        // 리뷰를 작성한 주문들만 필터링
+        const reviewedOrders = orders.filter((order) => order.reviewStatus === "done");
+
+        if (reviewedOrders.length === 0) {
+          setReviews([]);
+          setIsLoading(false);
+          return;
+        }
+
+        // 각 가게의 리뷰를 가져오고, 본인의 리뷰만 필터링
+        const allReviews: ReviewWithStore[] = [];
+        const storeIds = Array.from(new Set(reviewedOrders.map((o) => o.storeId)));
+
+        for (const storeId of storeIds) {
+          try {
+            const storeReviews = await getStoreReviews(storeId, controller.signal);
+            const storeName = reviewedOrders.find((o) => o.storeId === storeId)?.storeName || "";
+
+            // 모든 리뷰에 가게 이름을 추가
+            storeReviews.forEach((review) => {
+              allReviews.push({
+                ...review,
+                storeName,
+              });
+            });
+          } catch (e: unknown) {
+            if (e instanceof DOMException && e.name === "AbortError") return;
+          }
+        }
+
+        // 최신순으로 정렬
+        allReviews.sort(
+          (a, b) =>
+            new Date(b.reviewCreatedAt).getTime() - new Date(a.reviewCreatedAt).getTime()
+        );
+
+        setReviews(allReviews);
+      } catch (e: unknown) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
+        setError("리뷰를 불러오지 못했습니다.");
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchReviews();
+
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <div className="space-y-4 px-5 py-6">
+      <div>
+        <h1 className="text-xl font-bold">리뷰</h1>
+        <p className="text-sm text-gray-600">작성한 리뷰를 확인할 수 있습니다.</p>
+      </div>
+
+      {isLoading && <p className="text-center text-sm text-gray-500 py-12">불러오는 중...</p>}
+
+      {error && (
+        <p className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">{error}</p>
+      )}
+
+      {!isLoading && !error && reviews.length === 0 && (
+        <div className="text-center py-12">
+          <p className="text-sm text-gray-500">작성한 리뷰가 없습니다.</p>
+        </div>
+      )}
+
+      {reviews.length > 0 && (
+        <div className="space-y-3">
+          {reviews.map((review) => (
+            <Card key={review.reviewId} className="p-4">
+              <div className="flex gap-3">
+                <img
+                  src={review.reviewImageUrl}
+                  alt={`${review.menuName} 리뷰 사진`}
+                  className="size-20 flex-shrink-0 rounded-lg bg-gray-200 object-cover"
+                />
+
+                <div className="flex flex-1 flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-500 font-semibold">
+                      {review.storeName}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm" aria-label={`별점 ${review.reviewRating}점`}>
+                      <span className="text-yellow-400">
+                        {"★".repeat(review.reviewRating)}
+                      </span>
+                      <span className="text-gray-300">
+                        {"★".repeat(5 - review.reviewRating)}
+                      </span>
+                    </span>
+                    <span className="text-xs text-gray-500">{review.menuName}</span>
+                  </div>
+
+                  <p className="text-sm text-gray-700">{review.reviewContent}</p>
+
+                  <span className="text-xs text-gray-500 pt-1">
+                    {formatOrderDate(review.reviewCreatedAt)}
+                  </span>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/customer/ReviewsPage/index.ts
+++ b/frontend/src/pages/customer/ReviewsPage/index.ts
@@ -1,0 +1,1 @@
+export { ReviewsPage } from './ReviewsPage';

--- a/frontend/src/pages/customer/index.ts
+++ b/frontend/src/pages/customer/index.ts
@@ -1,3 +1,4 @@
 export * from './HomePage';
 export * from './OrderPage';
 export * from './OrderHistoryPage';
+export * from './ReviewsPage';

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -8,6 +8,7 @@ import {
   HomePage,
   OrderPage,
   OrderHistoryPage,
+  ReviewsPage,
   OnboardingPage,
   CustomerLoginPage,
   OwnerLoginPage,
@@ -111,6 +112,7 @@ export function AppRoutes() {
         <Route path="/home" element={<HomePage />} />
         <Route path="/order/:storeId" element={<OrderPage />} />
         <Route path="/order-history" element={<OrderHistoryPage />} />
+        <Route path="/reviews" element={<ReviewsPage />} />
       </Route>
 
       <Route

--- a/frontend/src/shared/layout/CustomerLayout/BottomNavigation/BottomNavigation.tsx
+++ b/frontend/src/shared/layout/CustomerLayout/BottomNavigation/BottomNavigation.tsx
@@ -2,11 +2,11 @@ import { NavLink } from "react-router-dom";
 
 export function BottomNavigation() {
   return (
-    <nav className="sticky bottom-0 flex h-16 bg-white">
+    <nav className="sticky bottom-0 flex h-16 bg-white border-t border-line-100">
       <NavLink
         to="/home"
         className={({ isActive }) =>
-          `flex-1 flex items-center justify-center text-sm ${isActive ? "text-blue-600 font-bold" : "text-gray-500"}`
+          `flex-1 flex items-center justify-center text-xs font-semibold ${isActive ? "text-brand-800" : "text-ink-500"}`
         }
       >
         홈
@@ -14,10 +14,18 @@ export function BottomNavigation() {
       <NavLink
         to="/order-history"
         className={({ isActive }) =>
-          `flex-1 flex items-center justify-center text-sm ${isActive ? "text-blue-600 font-bold" : "text-gray-500"}`
+          `flex-1 flex items-center justify-center text-xs font-semibold ${isActive ? "text-brand-800" : "text-ink-500"}`
         }
       >
         주문내역
+      </NavLink>
+      <NavLink
+        to="/reviews"
+        className={({ isActive }) =>
+          `flex-1 flex items-center justify-center text-xs font-semibold ${isActive ? "text-brand-800" : "text-ink-500"}`
+        }
+      >
+        리뷰
       </NavLink>
     </nav>
   );

--- a/frontend/src/shared/layout/CustomerLayout/CustomerLayout.tsx
+++ b/frontend/src/shared/layout/CustomerLayout/CustomerLayout.tsx
@@ -6,7 +6,7 @@ export function CustomerLayout() {
   const location = useLocation();
 
   const showBottomNavigation =
-    location.pathname === "/home" || location.pathname === "/order-history";
+    location.pathname === "/home" || location.pathname === "/order-history" || location.pathname === "/reviews";
 
   return (
     <div className="min-h-screen bg-gray-100">


### PR DESCRIPTION
don't approve.

- GET /api/stores 에 page, size 쿼리 파라미터 추가 (기본 0, 20)
- StoreRepository.findAllByOrderByIdDesc(Pageable) → Page<Store> 반환으로 변경
- 프론트 홈에서 20개씩 끊어 받고 스크롤 시 다음 페이지 요청

홈 화면 들어갔을 때 콘솔에 PAGE = 0, SIZE = 20 이 찍히는지, 그리고 GET /api/stores?page=0&size=20 응답 배열이 정확히 20개인지 봐주세요. 
스크롤 내렸을 때 PAGE = 1 이 이어서 찍히는지도요. (20개 넘어갈 떄마다 page = 2, page = 3.. 이렇게 찍혀야합니다.)