### PR TITLE
[feat] 홈 가게 목록에 정렬(최신순/리뷰순) 추가

### DIFF
--- a/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** application.yml 의 reviewticket.* 를 그대로 받는다. */
 @ConfigurationProperties(prefix = "reviewticket")
 public record ReviewTicketProperties(
-        String demoDir, Auth auth, Mail mail, Cors cors, Order order, Ai ai, Upload upload, Review review, Store store) {
+        String demoDir, Auth auth, Mail mail, Cors cors, Order order, Ai ai, Upload upload, Review review) {
 
     /**
      * @param jwtSecret       서명 키. 32바이트 이상. application-local.yml 에 둔다
@@ -79,10 +79,10 @@ public record ReviewTicketProperties(
     }
 
     /**
-    * 홈 가게 목록.
-    *
-    * @param pinnedName 목록 맨 위에 고정할 가게 이름. 비어 있으면 고정하지 않는다
-    */
+     * 홈 가게 목록.
+     *
+     * @param pinnedName 목록 맨 위에 고정할 가게 이름. 비어 있으면 고정하지 않는다
+     */
     public record Store(String pinnedName) {
     }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/config/ReviewTicketProperties.java
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /** application.yml 의 reviewticket.* 를 그대로 받는다. */
 @ConfigurationProperties(prefix = "reviewticket")
 public record ReviewTicketProperties(
-        String demoDir, Auth auth, Mail mail, Cors cors, Order order, Ai ai, Upload upload, Review review) {
+        String demoDir, Auth auth, Mail mail, Cors cors, Order order, Ai ai, Upload upload, Review review, Store store) {
 
     /**
      * @param jwtSecret       서명 키. 32바이트 이상. application-local.yml 에 둔다
@@ -76,5 +76,13 @@ public record ReviewTicketProperties(
      *                         목표치가 같아야 사진이 늘어나는 일 없이 항상 줄이기만 하면 된다
      */
     public record Review(int contentMinLength, int contentMaxLength, int minImageLongEdge) {
+    }
+
+    /**
+    * 홈 가게 목록.
+    *
+    * @param pinnedName 목록 맨 위에 고정할 가게 이름. 비어 있으면 고정하지 않는다
+    */
+    public record Store(String pinnedName) {
     }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/StoreRepository.java
@@ -11,8 +11,11 @@ import com.reviewticket.server.domain.User;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
 
-    /** 홈 목록. 최신 가게가 먼저 온다. */
+    // 홈 목록 - 최신순. 등록 역순
     Page<Store> findAllByOrderByIdDesc(Pageable pageable);
+
+    // 홈 목록 - 리뷰 많은 순
+    Page<Store> findAllByOrderByReviewNumberDescIdDesc(Pageable pageable);
 
     boolean existsByOwner(User owner);
 

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreController.java
@@ -72,12 +72,13 @@ public class StoreController {
             boolean reviewEvent, Instant menuLatestUpdate) {
     }
 
-    /** 홈 목록. 페이지네이션 지원 (20개씩 응답). */
+    /** 홈 목록. 페이지네이션 지원 (20개씩 응답) + 정렬. sort 생략 시 최신순으로 정렬 */
     @GetMapping
     public List<StoreSummaryResponse> stores(
-        @RequestParam(defaultValue = "0") int page,
-        @RequestParam(defaultValue = "20") int size) {
-            return storeService.findAll(page, size);
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "LATEST") StoreService.StoreSort sort) {
+        return storeService.findAll(page, size, sort);
     }
 
     /** 주문 화면용 상세. 가게 정보 + 그 가게의 메뉴 배열. */
@@ -97,7 +98,8 @@ public class StoreController {
     public UpdateStoreResponse updateMyStore(@AuthenticationPrincipal User user,
             @Valid @RequestBody UpdateStoreRequest request) {
         StoreMeResponse updated = storeService.updateMine(user.getId(), request.storeName(), request.logoUrl());
-        return new UpdateStoreResponse(updated.storeId(), updated.storeName(), updated.logoUrl(), updated.latestUpdate());
+        return new UpdateStoreResponse(updated.storeId(), updated.storeName(), updated.logoUrl(),
+                updated.latestUpdate());
     }
 
     /** 사장이 자기 가게 메뉴를 조회한다. */

--- a/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/store/StoreService.java
@@ -6,11 +6,11 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Page;
 
 import com.reviewticket.server.auth.ConflictException;
 import com.reviewticket.server.auth.ForbiddenException;
@@ -45,6 +45,17 @@ public class StoreService {
     private final ImageStorage storage;
     private final ImageResizer resizer;
     private final ReviewTicketProperties properties;
+
+    /**
+     * 홈 목록 정렬 기준. 어느 값이든 고정 가게(reviewticket.store.pinned-name)가
+     * 항상 맨 위다 — 고정은 정렬 옵션이 아니라 그 위에 얹는 규칙이다.
+     */
+    public enum StoreSort {
+        /** 등록 역순(기존 동작) */
+        LATEST,
+        /** 리뷰 많은 순 */
+        REVIEWS
+    }
 
     public StoreService(StoreRepository stores, MenuRepository menus,
             UserRepository users, PendingSignupRepository pendings, EntityManager entityManager,
@@ -81,15 +92,19 @@ public class StoreService {
 
     /** 홈 목록. 최신 가게가 먼저 온다. 페이지네이션 지원 (20개씩 응답). */
     @Transactional(readOnly = true)
-    public List<StoreSummaryResponse> findAll(int page, int size) {
+    public List<StoreSummaryResponse> findAll(int page, int size, StoreSort sort) {
 
+        // Sort 를 넣지 않음 - @Query 에 이미 ORDER BY 가 있고, Pageable 의 Sort 는 그 뒤에 덧붙여져 정렬 조건이
+        // 두번 적힘.
         Pageable pageable = PageRequest.of(
-            page,
-            size,
-            Sort.by(Sort.Direction.DESC, "id")
-        );
+                page,
+                size);
 
-        return stores.findAllByOrderByIdDesc(pageable)
+        Page<Store> found = (sort == StoreSort.REVIEWS)
+                ? stores.findAllByOrderByReviewNumberDescIdDesc(pageable)
+                : stores.findAllByOrderByIdDesc(pageable);
+
+        return found
                 .map(StoreService::toSummary)
                 .getContent();
     }

--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -101,9 +101,6 @@ reviewticket:
     # upload.target-long-edge 와 같은 값이어야 한다 — 하한과 목표치가 같아야
     # 리사이즈가 항상 줄이기만 하고 늘리는 일이 없다.
     min-image-long-edge: 1920
-  store:
-    # 홈 가게 목록 맨 위에 고정할 가게. 비우면 최신순 그대로.
-    pinned-name: "썬더치킨 별내점"
   cors:
     # 쿠키를 쓰지 않고 Authorization 헤더로만 인증하므로(allowCredentials 꺼짐)
     # 출처를 전부 열어도 쿠키 기반 CSRF 같은 위험이 생기지 않는다.

--- a/backend/Server/src/main/resources/application.yml
+++ b/backend/Server/src/main/resources/application.yml
@@ -48,7 +48,7 @@ server:
   port: 60921
   tomcat:
     threads:
-      max: 100                  # 기본 200 은 이 서버엔 과하다
+      max: 100 # 기본 200 은 이 서버엔 과하다
 
 # ---- 이 서비스 전용 설정 ----
 reviewticket:
@@ -101,6 +101,9 @@ reviewticket:
     # upload.target-long-edge 와 같은 값이어야 한다 — 하한과 목표치가 같아야
     # 리사이즈가 항상 줄이기만 하고 늘리는 일이 없다.
     min-image-long-edge: 1920
+  store:
+    # 홈 가게 목록 맨 위에 고정할 가게. 비우면 최신순 그대로.
+    pinned-name: "썬더치킨 별내점"
   cors:
     # 쿠키를 쓰지 않고 Authorization 헤더로만 인증하므로(allowCredentials 꺼짐)
     # 출처를 전부 열어도 쿠키 기반 CSRF 같은 위험이 생기지 않는다.

--- a/frontend/src/api/storeApi.ts
+++ b/frontend/src/api/storeApi.ts
@@ -1,7 +1,6 @@
 import { request } from "@/shared/api";
 import type { Store } from "@/entities/store";
 
-// 이도연
 export interface MenuItem {
   id: number;
   name: string;
@@ -13,17 +12,6 @@ export interface MenuItem {
 
 export interface StoreDetail extends Store {
   menus: MenuItem[];
-}
-
-export function getStores(
-  page: number,
-  size: number,
-  signal?: AbortSignal,
-): Promise<Store[]> {
-  return request<Store[]>(`/stores?page=${page}&size=${size}`, {
-    auth: true,
-    signal,
-  });
 }
 
 export function getStoreDetail(
@@ -145,5 +133,19 @@ export function updateMyMenu(
     method: "PATCH",
     body: patch,
     auth: true,
+  });
+}
+
+export type StoreSort = "LATEST" | "REVIEWS";
+
+export function getStores(
+  page: number,
+  size: number,
+  sort: StoreSort = "LATEST",
+  signal?: AbortSignal,
+): Promise<Store[]> {
+  return request<Store[]>(`/stores?page=${page}&size=${size}&sort=${sort}`, {
+    auth: true,
+    signal,
   });
 }

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@/app/providers";
 import { getStores } from "@/api/storeApi";
 import { STORE_CACHE_KEY } from "@/entities/store/storeCache";
 import type { Store } from "@/entities/store";
+import type { StoreSort } from "@/api/storeApi";
 
 function getCachedStores(): Store[] | null {
   const cached = localStorage.getItem(STORE_CACHE_KEY);
@@ -56,37 +57,48 @@ export function HomePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const [sort, setSort] = useState<StoreSort>("LATEST");
+  const sortRef = useRef(sort);
+
+  sortRef.current = sort;
 
   useEffect(() => {
     setSelectedFoodIndex(Math.floor(Math.random() * FOODS.length));
   }, []);
 
   useEffect(() => {
-    // 캐시가 있으면 먼저 그려 첫 화면이 비어 보이지 않게 한다.
-    const cached = getCachedStores();
-    if (cached) {
-      setStores(cached);
+    const controller = new AbortController();
+
+    // 정렬 기준이 바뀌면 기존 목록을 비우고 첫 페이지부터 다시 조회
+    setStores([]);
+    setPage(0);
+    setHasMore(true);
+
+    // 현재 캐시는 LATEST 목록에서만 사용
+    if (sort === "LATEST") {
+      const cached = getCachedStores();
+      if (cached) setStores(cached);
     }
 
-    // 캐시가 있어도 서버에 반드시 다시 물어본다. 이 목록에는 리뷰 수와 평균
-    // 별점이 함께 들어 있는데, 그 둘은 리뷰가 등록될 때마다 바뀌는 값이다.
-    // 캐시에서 멈추면 리뷰를 써도 홈 화면은 자정까지 예전 숫자(리뷰 0)를
-    // 보여줘, 등록이 안 된 것처럼 보인다.
-    // 첫 페이지는 0번이다. 여기서 받은 결과로 page 를 1로 올려야 아래 옵저버의
-    // page <= 0 가드가 풀린다 — 올리지 않으면 무한 스크롤이 한 번도 발동하지 않는다.
-    getStores(0, 20)
+    // 캐시가 있어도 서버에 반드시 다시 요청
+    // 리뷰수와 평균 별점은 리뷰 등록 시 변경될 수 있기 때문이다.
+    // 첫 페이지는 0번. 조회 성공 후 page 를 1로 올려 다음 페이지 요청 준비.
+    getStores(0, 20, sort, controller.signal)
       .then((data) => {
-        setStores(data);
+        setStores(data); // 서버 결과로 교체
         setPage(1);
         setHasMore(data.length === 20);
-        if (data.length > 0) {
+
+        if (sort === "LATEST" && data.length > 0) {
           setCachedStores(data, 1);
         }
       })
       .catch(() => {
         // 서버에 닿지 못하면 위에서 그린 캐시를 그대로 둔다. 캐시도 없으면 빈 상태다.
       });
-  }, []);
+
+    return () => controller.abort();
+  }, [sort]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -96,13 +108,11 @@ export function HomePage() {
         }
 
         setIsLoading(true);
-        getStores(page, 20)
+        getStores(page, 20, sort)
           .then((data) => {
-            setStores((prev) => {
-              const updated = [...prev, ...data];
-              setCachedStores(updated, page + 1);
-              return updated;
-            });
+            if (sortRef.current !== sort) return;
+
+            setStores((prev) => [...prev, ...data]);
 
             if (data.length < 20) {
               setHasMore(false);
@@ -127,7 +137,7 @@ export function HomePage() {
     return () => {
       observer.disconnect();
     };
-  }, [page, isLoading, hasMore]);
+  }, [page, isLoading, hasMore, sort]);
 
   return (
     <div className="flex flex-col gap-8 px-5 py-6">
@@ -153,6 +163,23 @@ export function HomePage() {
         <h2 className="text-base font-bold text-ink-900">
           지금 주문할 수 있는 가게
         </h2>
+        <div className="flex gap-1">
+          {(["LATEST", "REVIEWS"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setSort(value)}
+              aria-pressed={sort === value}
+              className={`rounded-lg px-3 py-1.5 text-xs transition-colors ${
+                sort === value
+                  ? "font-bold text-brand-800"
+                  : "font-semibold text-ink-500 hover:text-ink-900"
+              }`}
+            >
+              {value === "LATEST" ? "최신순" : "리뷰많은순"}
+            </button>
+          ))}
+        </div>
 
         {stores.length === 0 && !isLoading ? (
           <EmptyState

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -93,8 +93,9 @@ export function HomePage() {
           setCachedStores(data, 1);
         }
       })
-      .catch(() => {
-        // 서버에 닿지 못하면 위에서 그린 캐시를 그대로 둔다. 캐시도 없으면 빈 상태다.
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === "AbortError")
+          return;
       });
 
     return () => controller.abort();

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,14 +9,14 @@ export default defineConfig(({ mode }) => {
   // 공용 서버를 쓰면 그 주소다. 코드에 박아두면 주소가 바뀔 때마다 커밋하고
   // 팀원 전원이 pull 을 받아야 하므로 .env.local 에서 읽는다
   // (*.local 은 .gitignore 에 걸려 커밋되지 않는다. .env.example 참고)
-  const env = loadEnv(mode, __dirname, "VITE_");
+  const env = loadEnv(mode, import.meta.dirname, "VITE_");
   const apiTarget = env.VITE_API_TARGET || "http://localhost:60921";
 
   return {
     plugins: [react(), tailwindcss()],
     resolve: {
       alias: {
-        "@": path.resolve(__dirname, "./src"),
+        "@": path.resolve(import.meta.dirname, "./src"),
       },
     },
     server: {


### PR DESCRIPTION
## 변경
- `GET /api/stores` 에 `sort` 파라미터 추가 (기본 `LATEST`, 그 외 `REVIEWS`)
- `StoreRepository` 파생 쿼리 2개로 분기. 리뷰순은 `review_number DESC, store_id DESC` — 동점 가게 순서가 페이지마다 흔들리면 무한 스크롤에서 중복·누락이 생겨 `id` 를 마지막 기준으로 둠
- 프론트: 정렬 토글 UI 추가, 전환 시 목록을 비우고 첫 페이지부터 재조회
- localStorage 캐시는 `LATEST` 에만 적용. 이전 정렬의 응답이 늦게 도착해 섞이지 않도록 `sortRef` 가드 추가

## 테스트
`?sort=LATEST` 등록 역순, `?sort=REVIEWS` 리뷰 수 내림차순 확인. 스크롤 도중 정렬을 바꿔도 목록이 섞이지 않음.