### PR TITLE
feat: 웹 푸시 알림 기능 구현

### DIFF
--- a/backend/Server/build.gradle
+++ b/backend/Server/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	// JWT. api 만 컴파일에 노출하고 구현체는 런타임에만 둔다 —
 	// 실수로 내부 클래스를 직접 import 하는 걸 막는다.
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	// web-push
+	implementation 'nl.martijndwars:web-push:5.1.1'
+	implementation 'org.bouncycastle:bcprov-jdk18on:1.81'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/Server/src/main/java/com/reviewticket/server/domain/Notification.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/domain/Notification.java
@@ -1,0 +1,60 @@
+package com.reviewticket.server.domain;
+
+import com.reviewticket.server.domain.Notification;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "notification_subscriptions")
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 512, unique = true)
+    private String endpoint;
+
+    @Column(nullable = false, length = 200)
+    private String p256dh;
+
+    @Column(nullable = false, length = 100)
+    private String auth;
+
+    protected Notification() {
+    }
+
+    public Notification(
+            User user,
+            String endpoint,
+            String p256dh,
+            String auth) {
+        this.user = user;
+        this.endpoint = endpoint;
+        this.p256dh = p256dh;
+        this.auth = auth;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getP256dh() {
+        return p256dh;
+    }
+
+    public String getAuth() {
+        return auth;
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationController.java
@@ -1,0 +1,26 @@
+package com.reviewticket.server.notification;
+
+import com.reviewticket.server.domain.User;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @PostMapping("/subscription")
+    public ResponseEntity<Void> saveSubscription(
+            @AuthenticationPrincipal User user,
+            @Valid @RequestBody NotificationRequest request) {
+        notificationService.saveSubscription(user.getId(), request);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationController.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationController.java
@@ -23,4 +23,12 @@ public class NotificationController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/test")
+    public ResponseEntity<Void> sendToCustomers(
+            @AuthenticationPrincipal User user) throws Exception {
+
+        notificationService.sendToCustomers();
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationRequest.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationRequest.java
@@ -1,0 +1,9 @@
+package com.reviewticket.server.notification;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NotificationRequest(
+                @NotBlank String endpoint,
+                @NotBlank String p256dh,
+                @NotBlank String auth) {
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationService.java
@@ -5,39 +5,64 @@ import com.reviewticket.server.repository.NotificationRepository;
 import com.reviewticket.server.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.reviewticket.server.domain.Role;
 
 @Service
 public class NotificationService {
 
-    private final NotificationRepository notificationRepository;
-    private final UserRepository userRepository;
+        private final NotificationRepository notificationRepository;
+        private final UserRepository userRepository;
+        private final WebPushService webPushService;
 
-    public NotificationService(
-            NotificationRepository notificationRepository,
-            UserRepository userRepository) {
-        this.notificationRepository = notificationRepository;
-        this.userRepository = userRepository;
-    }
-
-    @Transactional
-    public void saveSubscription(
-            Long userId,
-            NotificationRequest request) {
-        var user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
-
-        var existing = notificationRepository
-                .findByEndpoint(request.endpoint());
-
-        if (existing.isPresent()) {
-            return;
+        public NotificationService(
+                        NotificationRepository notificationRepository,
+                        UserRepository userRepository,
+                        WebPushService webPushService) {
+                this.notificationRepository = notificationRepository;
+                this.userRepository = userRepository;
+                this.webPushService = webPushService;
         }
 
-        notificationRepository.save(
-                new Notification(
-                        user,
-                        request.endpoint(),
-                        request.p256dh(),
-                        request.auth()));
-    }
+        @Transactional
+        public void saveSubscription(
+                        Long userId,
+                        NotificationRequest request) {
+                var user = userRepository.findById(userId)
+                                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+                var existing = notificationRepository
+                                .findByEndpoint(request.endpoint());
+
+                if (existing.isPresent()) {
+                        return;
+                }
+
+                notificationRepository.save(
+                                new Notification(
+                                                user,
+                                                request.endpoint(),
+                                                request.p256dh(),
+                                                request.auth()));
+        }
+
+        @Transactional(readOnly = true)
+        public void sendToCustomers() throws Exception {
+
+                var subscriptions = notificationRepository.findAllByUserRole(Role.CUSTOMER);
+
+                String payload = """
+                                {
+                                  "title": "Review Ticket",
+                                  "body": "점심 시간이 다가오고 있어요!\n오늘 점심은 무엇을 주문할까요?"
+                                }
+                                """;
+
+                for (var subscription : subscriptions) {
+                        webPushService.send(
+                                        subscription.getEndpoint(),
+                                        subscription.getP256dh(),
+                                        subscription.getAuth(),
+                                        payload);
+                }
+        }
 }

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/NotificationService.java
@@ -1,0 +1,43 @@
+package com.reviewticket.server.notification;
+
+import com.reviewticket.server.domain.Notification;
+import com.reviewticket.server.repository.NotificationRepository;
+import com.reviewticket.server.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    public NotificationService(
+            NotificationRepository notificationRepository,
+            UserRepository userRepository) {
+        this.notificationRepository = notificationRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional
+    public void saveSubscription(
+            Long userId,
+            NotificationRequest request) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        var existing = notificationRepository
+                .findByEndpoint(request.endpoint());
+
+        if (existing.isPresent()) {
+            return;
+        }
+
+        notificationRepository.save(
+                new Notification(
+                        user,
+                        request.endpoint(),
+                        request.p256dh(),
+                        request.auth()));
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/notification/WebPushService.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/notification/WebPushService.java
@@ -1,0 +1,48 @@
+package com.reviewticket.server.notification;
+
+import nl.martijndwars.webpush.Notification;
+import nl.martijndwars.webpush.PushService;
+import nl.martijndwars.webpush.Subscription;
+import java.security.GeneralSecurityException;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import java.security.Security;
+
+@Service
+public class WebPushService {
+
+    private final PushService pushService;
+
+    public WebPushService(
+            @Value("${webpush.vapid.public-key}") String publicKey,
+            @Value("${webpush.vapid.private-key}") String privateKey,
+            @Value("${webpush.vapid.subject}") String subject) {
+        try {
+            Security.addProvider(new BouncyCastleProvider());
+
+            this.pushService = new PushService(publicKey, privateKey, subject);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException(
+                    "VAPID 키 초기화에 실패했습니다.",
+                    e);
+        }
+    }
+
+    public void send(
+            String endpoint,
+            String p256dh,
+            String auth,
+            String payload) throws Exception {
+
+        Subscription.Keys keys = new Subscription.Keys(p256dh, auth);
+
+        Subscription subscription = new Subscription(endpoint, keys);
+
+        Notification notification = new Notification(subscription, payload);
+
+        pushService.send(
+                notification);
+    }
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/NotificationRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.reviewticket.server.repository;
+
+import com.reviewticket.server.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationRepository
+        extends JpaRepository<Notification, Long> {
+
+    Optional<NotificationRepository> findByEndpoint(String endpoint);
+}

--- a/backend/Server/src/main/java/com/reviewticket/server/repository/NotificationRepository.java
+++ b/backend/Server/src/main/java/com/reviewticket/server/repository/NotificationRepository.java
@@ -2,11 +2,23 @@ package com.reviewticket.server.repository;
 
 import com.reviewticket.server.domain.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.reviewticket.server.domain.Role;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository
         extends JpaRepository<Notification, Long> {
 
     Optional<NotificationRepository> findByEndpoint(String endpoint);
+
+    @Query("""
+                SELECT n
+                FROM Notification n
+                JOIN FETCH n.user u
+                WHERE u.role = :role
+            """)
+    List<Notification> findAllByUserRole(@Param("role") Role role);
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -5,3 +5,17 @@ self.addEventListener("install", () => {
 self.addEventListener("activate", (event) => {
   event.waitUntil(self.clients.claim());
 });
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  const data = event.data.json();
+
+  event.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body,
+      icon: "/icons/icon-192.png",
+      badge: "/icons/icon-192.png",
+    }),
+  );
+});

--- a/frontend/src/api/notificationApi.ts
+++ b/frontend/src/api/notificationApi.ts
@@ -1,0 +1,5 @@
+export interface PushSubscriptionRequest {
+  endpoint: string;
+  p256dh: string;
+  auth: string;
+}

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -9,6 +9,7 @@ import { STORE_CACHE_KEY } from "@/entities/store/storeCache";
 import type { Store } from "@/entities/store";
 import type { StoreSort } from "@/api/storeApi";
 import { Modal } from "@/shared/ui/Modal";
+import { request } from "@/shared/api/client";
 
 function getCachedStores(): Store[] | null {
   const cached = localStorage.getItem(STORE_CACHE_KEY);
@@ -114,6 +115,20 @@ export function HomePage() {
           userVisibleOnly: true,
           applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
         });
+
+        const subscriptionJson = subscription.toJSON();
+
+        await request("/notifications/subscription", {
+          method: "POST",
+          auth: true,
+          body: {
+            endpoint: subscriptionJson.endpoint,
+            p256dh: subscriptionJson.keys?.p256dh,
+            auth: subscriptionJson.keys?.auth,
+          },
+        });
+
+        console.log("Push Subscription:", subscription);
       }
 
       console.log("Push Subscription:", subscription);

--- a/frontend/src/pages/customer/HomePage/HomePage.tsx
+++ b/frontend/src/pages/customer/HomePage/HomePage.tsx
@@ -80,6 +80,19 @@ export function HomePage() {
     };
   }, []);
 
+  const handleTestNotification = async () => {
+    try {
+      await request("/notifications/test", {
+        method: "POST",
+        auth: true,
+      });
+
+      console.log("테스트 알림 발송 요청 성공");
+    } catch (error) {
+      console.error("테스트 알림 발송 실패:", error);
+    }
+  };
+
   const handleAllowNotification = async () => {
     if (!("Notification" in window)) return;
     if (!("serviceWorker" in navigator)) return;
@@ -248,6 +261,14 @@ export function HomePage() {
           description="리뷰 배지가 붙은 가게에서 주문하고 사진 리뷰를 남기면 티켓을 받아요."
         />
       </section>
+
+      <button
+        type="button"
+        onClick={handleTestNotification}
+        className="px-4 py-2 bg-black text-white rounded"
+      >
+        테스트 알림 보내기
+      </button>
 
       {/* Store List Section */}
       <section className="flex flex-col gap-3">


### PR DESCRIPTION
## 변경 사항
- 브라우저 알림 권한 요청 및 PushSubscription 생성
- PushSubscription 서버 저장 API 구현
- VAPID 기반 Web Push 발송 기능 구현
- Service Worker를 통한 알림 수신 구현
- 알림 테스트 API 구현

## 테스트
- CUSTOMER 로그인 후 알림 권한 허용
- 테스트 알림 발송 및 브라우저 알림 수신 확인